### PR TITLE
(fix) ACP systemPrompt section cold-start retry — add internal/service listener for systemPrompt service (#5)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -216,13 +216,34 @@ export class AcpCompactionEngine extends CompactionEngine {
       })
     }
     // The load-bearing ACP guidance lives in the system prompt ONCE; nudges
-    // stay short and advisory (model-driven: the model decides).
+    // stay short and advisory (model-driven: the model decides). The
+    // systemPrompt service may not be registered yet on cold start (cordis
+    // starts unrelated composition rows concurrently), so apply the same
+    // retry pattern as tools and commands: eager registration, then
+    // re-attempt when the service appears via `internal/service`; guard so a
+    // late callback never double-registers.
     const systemPrompt = ctx.get('systemPrompt')
     if (systemPrompt !== undefined) {
       systemPrompt.section({
         name: 'billion-context-dsh',
         order: ACP_SYSTEM_PROMPT_ORDER,
         text: ACP_SYSTEM_PROMPT,
+      })
+    } else {
+      let done = false
+      const registerSystemPrompt = (): void => {
+        if (done) return
+        const registry = ctx.get('systemPrompt')
+        if (registry === undefined) return
+        done = true
+        registry.section({
+          name: 'billion-context-dsh',
+          order: ACP_SYSTEM_PROMPT_ORDER,
+          text: ACP_SYSTEM_PROMPT,
+        })
+      }
+      ctx.on('internal/service', (name: unknown) => {
+        if (name === 'systemPrompt') registerSystemPrompt()
       })
     }
   }

--- a/tests/mount-probe.test.ts
+++ b/tests/mount-probe.test.ts
@@ -1,7 +1,9 @@
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
 import { Context } from '@deepseek-ai/cordis'
+import { SystemPrompt } from '@deepseek-ai/dsh-system-prompt'
 import AcpCompactionEngine, { AcpCompactionEngine as Named } from '../src/index.ts'
+import { ACP_SYSTEM_PROMPT } from '../src/system-prompt.ts'
 import { eventsToCoreMessages, projectEvent } from '../src/messages.ts'
 
 test('M0: AcpCompactionEngine mounts on a bare Cordis context', async () => {
@@ -93,4 +95,36 @@ test('M1: non-surface events project to nothing', () => {
   ] as never[]
   const projected = events.map((event) => projectEvent(event as never))
   assert.deepEqual(projected, [[], []])
+})
+
+// Regression: issue #5 — ACP systemPrompt section must not be silently dropped
+// on cold start when the engine activates before the systemPrompt service.
+// Verifies the `internal/service` retry listener registers the section once
+// the service appears later.
+test('M4: ACP system prompt section registers when systemPrompt service appears after engine', async () => {
+  const ctx = new Context()
+  // Mount the engine FIRST — systemPrompt is not yet available, so the retry
+  // listener is registered in the else branch.
+  ctx.plugin(AcpCompactionEngine as never)
+  await new Promise((resolve) => setTimeout(resolve, 20))
+
+  // Confirm engine mounted and systemPrompt is still absent.
+  const engine = ctx.compaction as Named
+  assert.ok(engine instanceof Named, 'engine mounted before systemPrompt')
+  assert.equal(ctx.get('systemPrompt'), undefined, 'systemPrompt not yet available')
+
+  // Now mount the systemPrompt service — this should trigger internal/service
+  // and the retry listener should register the ACP section.
+  ctx.plugin(SystemPrompt, {})
+  await new Promise((resolve) => setTimeout(resolve, 20))
+
+  // Verify the section is registered by assembling the prompt.
+  const sp = ctx.get('systemPrompt')
+  assert.ok(sp !== undefined, 'systemPrompt is now available')
+  const assembly = await sp.assemble()
+  assert.ok(assembly.sections.length >= 1, 'at least one section in the assembly')
+  const acpSection = assembly.sections.find((s) => s.name === 'billion-context-dsh')
+  assert.ok(acpSection !== undefined, 'ACP section "billion-context-dsh" is present in the assembly')
+  assert.ok(acpSection!.text.includes('Active Context Pruning'), 'ACP section text is the real guidance prompt')
+  assert.ok(acpSection!.text === ACP_SYSTEM_PROMPT, 'ACP section text matches the exported constant')
 })


### PR DESCRIPTION
## Problem

Fixes #5

The `systemPrompt` section registration in `src/index.ts` uses a one-shot `ctx.get('systemPrompt')` check. When cordis starts composition rows concurrently, the engine row may activate before the `systemPrompt` service, causing the ACP guidance section to be silently dropped — no retry, no error.

Tools (`ctx.tools`) and commands (`ctx.commands`) already have a retry pattern via `internal/service` listener. The `systemPrompt` registration was missing this.

## Fix

Apply the same `internal/service` retry pattern to `systemPrompt` registration, matching the existing tools/commands implementation exactly:

- Eager registration when the service is available
- `internal/service` listener with `name === 'systemPrompt'` for cold-start retry
- `done` guard to prevent double-registration

## Changes

| File | Change |
|---|---|
| `src/index.ts` | +23 lines: retry pattern for systemPrompt section registration |
| `tests/mount-probe.test.ts` | +34 lines: regression test simulating cold-start scenario |

## Verification

- ✅ `npm run typecheck` passes
- ✅ `npm test` — 61/61 tests pass (including new regression test)
- ✅ New regression test confirms the section registers when `systemPrompt` service appears after engine activation