### PR TITLE
(feat) configurable per-stage prompts via config.prompts — nudge frames/range table/system prompt/tool descriptions as validated templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ src/
 ├── tools.ts        # M3: compress / decompress / search_context / acp_status
 ├── nudge.ts        # M4: advisory nudge (surface-computed range table)
 ├── system-prompt.ts# M4: one-time ACP guidance section
+├── prompts.ts      # M4: configurable prompt templates + render/validate (config.prompts)
 ├── config.ts       # kernel config assembly (thresholds + coreOverrides)
 └── commands.ts     # M4: /acp slash command
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,8 @@ npm run build       # tsup (inlines acp-kernel) + tsc --emitDeclarationOnly
 - Add a regression test for every bug fix (see tests/ for the battle-report tests: CJK estimation, stale-range filtering, lone tool expansion, legacy backfill).
 - Keep `@deepseek-ai/*` devDeps on the **0.1.0-rc.6 line** (aligned with `@deepseek-ai/dsh-compaction` peer). Do not mix rc lines.
 - **Git worktrees MUST be created inside `worktrees/`** in the project root (e.g. `git worktree add worktrees/<branch> <branch>`). The `worktrees/` directory is gitignored and never pushed. Never create worktrees outside the project.
+- **Docs must stay in sync with every PR** — before opening a PR, review the diff against the documentation: any behavior the change alters must match what the docs describe, and docs that state the old behavior must be updated in the same PR. A PR that changes behavior without touching docs is incomplete.
+- **Feature work MUST document itself** — every feature (any behavior addition or change) must add an explanation of the new capability in the relevant docs: user-facing config/options in `README.md` / `README.en.md`, install-time composition options in `docs/INSTALL.md`, design decisions in `docs/*-design.md`, and the module map / hard-won rules in `AGENTS.md` itself. Precedent: the `config.prompts` feature shipped its README section, INSTALL note, config table row, and design doc in the same PR.
 
 ### Commit messages
 

--- a/README.en.md
+++ b/README.en.md
@@ -76,6 +76,20 @@ That's it. Then add a composition row where a compaction backend is expected —
         modelContextLimit: 128000   # optional; omit to auto-detect the model's real window (fallback 128000)
 ```
 
+**(Optional) Custom prompt copy — `config.prompts`.** Every model-visible prompt (normal/emergency nudge opener, tier line, range table, the ACP system-prompt section, the four tool descriptions) ships with built-in copy that you can override per slot through the composition row's `config`. Templates support named placeholders (e.g. `{pct}` for nudges, `{surface}` for the range table) and are **validated at construction**: a misspelled placeholder fails engine startup (fail-fast) instead of leaking a literal `{pct}` into the model context:
+
+```yaml
+      config:
+        modelContextLimit: 128000
+        prompts:
+          nudge:
+            normal: 'Context usage is at {pct}%. This is a suggestion, not a requirement — you decide.'  # custom nudge opener
+          tools:
+            acpStatus: 'Report the ACP block ledger: compressed blocks, reclaimed tokens, and current context pressure.'  # custom tool description
+```
+
+See [docs/configurable-prompts-design.md](docs/configurable-prompts-design.md) for the full slot list, per-slot placeholders, and the empty-string/`null` semantics. Deployments that omit `prompts` behave exactly as before (default copy byte-identical).
+
 **Per-mode — an agent preset's `compaction` realm.** First *disable (or delete) the realm's existing `dsh-compaction-basic` row*, then mount this engine — two backends cannot coexist in the same realm:
 
 ```yaml
@@ -151,6 +165,7 @@ This project reuses `acp-kernel`'s compression core and `billion-context-pi`'s d
 | `autoTools` | `true` | Register the four model tools on `ctx.tools` |
 | `autoCommand` | `true` | Register the `/acp` command on `ctx.commands` |
 | `autoNudge` | `true` | Inject the nudge into `agent/pre-step` |
+| `prompts` | — | (optional) Custom prompt copy: per-slot overrides for nudge / range table / system prompt / tool descriptions (template + named placeholders, validated at construction; see “Custom prompt copy” above and [docs/configurable-prompts-design.md](docs/configurable-prompts-design.md)) |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,20 @@ npm install billion-context-dsh
         modelContextLimit: 128000   # 可选；省略时自动探测模型真实窗口（回退 128000）
 ```
 
+**（可选）自定义提示词文案 —— `config.prompts`。** 所有模型可见的提示词（普通/紧急 nudge 首句、tier 蒸馏行、范围表、ACP system prompt 段、四个工具描述）默认是内置文案，可通过组合行的 `config` 按槽位覆盖。模板支持命名占位符（如 nudge 的 `{pct}`、范围表的 `{surface}`），**构造期校验**：占位符拼写错误会在引擎启动时抛错（fail-fast），而不是把字面 `{pct}` 漏进模型上下文：
+
+```yaml
+      config:
+        modelContextLimit: 128000
+        prompts:
+          nudge:
+            normal: '上下文使用率 {pct}%。这是建议而非命令——由你决定是否压缩。'  # 中文 nudge 首句
+          tools:
+            acpStatus: '报告 ACP 块账本：压缩块数、回收 token、当前上下文压力。'  # 自定义工具描述
+```
+
+可配置槽位清单、每槽可用占位符、空串/`null` 语义见 [docs/configurable-prompts-design.md](docs/configurable-prompts-design.md)。未配置 `prompts` 的部署行为与以往完全一致（默认文案逐字节不变）。
+
 **单模式生效（agent preset 的 `compaction` realm）**。先在该 realm 内*禁用（或删除）原有的 `dsh-compaction-basic` 行*，再插入本引擎——同一 realm 内两个后端不能并存：
 
 ```yaml
@@ -153,6 +167,7 @@ DSH 的每个模型请求都派生自其 append-only 会话日志（*surface*）
 | `autoTools` | `true` | 在 `ctx.tools` 注册四个模型工具 |
 | `autoCommand` | `true` | 在 `ctx.commands` 注册 `/acp` 命令 |
 | `autoNudge` | `true` | 当内核建议时向 `agent/pre-step` 注入 nudge |
+| `prompts` | — | （可选）自定义提示词文案：nudge / 范围表 / system prompt / 工具描述按槽位覆盖（模板 + 命名占位符，构造期校验；见上文「自定义提示词文案」与 [docs/configurable-prompts-design.md](docs/configurable-prompts-design.md)） |
 
 ## 开发
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -49,6 +49,15 @@ npm install --prefix ~/.dsh/profiles/web ./billion-context-dsh-0.0.0.tgz
         # 显式配置则优先且跳过探测。分母配小（如百万窗口模型配 128K）
         # 会让使用率虚高 8 倍、nudge 过频。growth 触发阈值（50000）不随此值变化。
         modelContextLimit: 128000
+        # （可选）自定义提示词文案：按槽位覆盖 nudge / 范围表 / system prompt /
+        # 工具描述，模板 + 命名占位符，构造期校验（拼写错误启动即抛）。未配置时
+        # 用内置默认文案（逐字节不变）。槽位与占位符清单见
+        # docs/configurable-prompts-design.md。
+        # prompts:
+        #   nudge:
+        #     normal: '上下文使用率 {pct}%。这是建议而非命令——由你决定是否压缩。'
+        #   tools:
+        #     acpStatus: '报告 ACP 块账本：压缩块数、回收 token、当前上下文压力。'
 ```
 
 作用：host 平面注册 `ctx.compaction` + 四个模型工具 + `/acp` 命令 + `agent/pre-step` nudge 监听，所有模式共享一份。

--- a/docs/configurable-prompts-design.md
+++ b/docs/configurable-prompts-design.md
@@ -212,6 +212,8 @@ nudge 装配(精确复现现状 src/nudge.ts:125-138):
 ## 5. 默认值(DEFAULT_PROMPTS)—— 从现有源码逐字搬迁
 
 > 硬约束:以下默认模板渲染结果必须与当前源码输出**逐字节相同**;现有测试(`tests/nudge.test.ts` 断言 `/Tier 2: 1 tier-1 block\(s\) distillable \(4750 tokens\)/`、`/Surface: 12 nodes, seqs 1\.\.12/` 等)全部保持绿色。
+>
+> **实现时与 main v0.1.8 对齐**:本设计定稿于 main v0.1.7 时代,实现 rebase 到 v0.1.8 后,默认文案已同步 main 的新增内容——范围表 footer 追加 stale-seq 提示行(提交 `ea1de6a`)、compress 工具描述追加 stale-remap 句(同提交)、system prompt 的 compress/acp_status 描述行更新(同提交)。下方示例即实现 `DEFAULT_PROMPTS` 的逐字内容。
 
 ### 5.1 nudge
 
@@ -241,7 +243,8 @@ rangeTable: {
   header: 'Surface: {surface}',
   title:  'Compressible ranges (suggestions only — compress any consumed span; refs are surface seqs):',
   line:   '  - seq {start}..{end} — {count} messages, ~{tokens} tokens',
-  footer: 'Compress with: compress({ content: [{ startSeq, endSeq, summary }] }) — content is an array: batch multiple unrelated segments in one call, each entry its own block. Keep ranges disjoint.',
+  footer: 'Compress with: compress({ content: [{ startSeq, endSeq, summary }] }) — content is an array: batch multiple unrelated segments in one call, each entry its own block. Keep ranges disjoint.\n'
+    + 'Snapshot taken at nudge time: the seqs go stale once the surface moves (a later compress shadows them), so re-run acp_status for fresh refs before compressing.',
 }
 ```
 
@@ -273,7 +276,7 @@ systemPromptTemplate:
 
 ```ts
 tools: {
-  compress:      'Replace older conversation ranges with dense summaries you write. Each message seq is a surface reference. Single range: compress({ content: [{ startSeq, endSeq, summary }] }). Batch multiple unrelated ranges in one call (each content entry becomes its own block); keep ranges disjoint. Never compress content the current step is actively using.',
+  compress:      'Replace older conversation ranges with dense summaries you write. Each message seq is a surface reference. Single range: compress({ content: [{ startSeq, endSeq, summary }] }). Batch multiple unrelated ranges in one call (each content entry becomes its own block); keep ranges disjoint. Never compress content the current step is actively using. Seq refs must come from the CURRENT surface (acp_status or the latest nudge): a span whose edges were shadowed by an earlier compress is auto-remapped to its still-live content, a fully compressed span is reported as already compressed, and invented/other-session seqs fail with guidance.',
   decompress:    'Recover the original content of a compressed block by its blockId (read-only; does not unshadow the range).',
   searchContext: 'Search inside compressed blocks (summaries and original content) for information the model no longer sees in context.',
   acpStatus:     'Report the ACP block ledger: compressed blocks, reclaimed tokens, and current context pressure.',
@@ -303,6 +306,8 @@ tools: {
 - 未配置 `prompts` 的部署:行为与现在完全相同(默认模板渲染 = 现文案)。
 
 ## 8. 测试计划(新增 13 条 + 现有 54 条回归)
+
+> **实现落地**:新增 **15 条**(13 条单元对应下编 #1–#13,另加 2 条引擎级接线)——#14 用 `ctx.provide` 伪造 `systemPrompt`/`tools` + `agent/pre-step` waterfall 验证自定义文案进入注入消息、段落注册恰一次、工具描述自定义;#15 验证引擎构造器对未知占位符同步抛错(fail-fast)、组级 null 容忍。对应提交 `5fff5ae` / `832cbc4`。
 
 > **快照原则(I3/I4):** 所有"逐字节回归"断言用**硬编码在测试里的字面量**(实现改造前抄下来的当前输出),与实现分离——测试与实现不同源,改造引入的字节差异(em-dash、⚠️、尾部空格、换行)都会被抓住。不依赖"改造后的 ACP_SYSTEM_PROMPT 导出"作比较(那是循环论证)。
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,12 +41,27 @@ import { AcpStateStore } from './state.ts'
 import { makeTools, type ToolEnvironment } from './tools.ts'
 import { acpCommand } from './commands.ts'
 import { buildNudge } from './nudge.ts'
-import { ACP_SYSTEM_PROMPT, ACP_SYSTEM_PROMPT_ORDER } from './system-prompt.ts'
+import { ACP_SYSTEM_PROMPT_ORDER } from './system-prompt.ts'
+import { renderSystemPrompt, resolvePrompts, type AcpPrompts, type ResolvedPrompts } from './prompts.ts'
 import { DEFAULT_CONTEXT_WINDOW, detectContextWindow, type AcpWindow } from './window.ts'
 
 export { AcpStateStore } from './state.ts'
 export { kernelConfigFor, type KernelConfigInput } from './config.ts'
 export { ACP_SYSTEM_PROMPT, ACP_SYSTEM_PROMPT_ORDER } from './system-prompt.ts'
+export {
+  DEFAULT_PROMPTS,
+  DEFAULT_RESOLVED,
+  renderSystemPrompt,
+  renderTemplate,
+  resolvePrompts,
+  type AcpPrompts,
+  type NudgePrompts,
+  type PromptInput,
+  type PromptOverride,
+  type RangeTablePrompts,
+  type ResolvedPrompts,
+  type ToolPrompts,
+} from './prompts.ts'
 export { makeTools, type ToolEnvironment } from './tools.ts'
 export { acpCommand } from './commands.ts'
 export { buildNudge, resolveTokenCount, type NudgeEnvironment, type NudgeOutcome } from './nudge.ts'
@@ -122,6 +137,8 @@ export interface AcpConfig {
   readonly autoCommand: boolean
   /** Inject the nudge into `agent/pre-step` when the kernel recommends it. Default true. */
   readonly autoNudge: boolean
+  /** Per-stage prompt template overrides (nudge / range table / system prompt / tool descriptions). See docs/configurable-prompts-design.md. */
+  readonly prompts?: AcpPrompts
 }
 
 const DEFAULT_CONFIG: AcpConfig = {
@@ -154,6 +171,8 @@ export class AcpCompactionEngine extends CompactionEngine {
   readonly store: AcpStateStore
   /** Resolved engine configuration. */
   readonly config: AcpConfig
+  /** Resolved prompt templates (validated at construction — fail-fast on template typos). */
+  readonly prompts: ResolvedPrompts
 
   private readonly lastNudgeTurn = new Map<string, number>()
   /** Per provider/model route the resolved window (probe failures cached too). */
@@ -162,6 +181,9 @@ export class AcpCompactionEngine extends CompactionEngine {
   constructor(ctx: Context, config: Partial<AcpConfig> = {}) {
     super(ctx)
     this.config = resolveAcpConfig(config)
+    // Resolve + validate prompt templates BEFORE building env: a template typo
+    // must fail engine construction, never silently leak into model context.
+    this.prompts = resolvePrompts(config.prompts)
     const ports = this.config.countTokens !== undefined ? { countTokens: this.config.countTokens } : {}
     this.kernel = createCore(ports)
     this.store = new AcpStateStore()
@@ -176,6 +198,7 @@ export class AcpCompactionEngine extends CompactionEngine {
       nudgeEmergencyThresholdPct: this.config.nudgeEmergencyThresholdPct,
       coreOverrides: this.config.coreOverrides,
       windowFor: (agent) => this.windowFor(agent),
+      prompts: this.prompts,
     }
 
     // Tools and commands may not be registered yet on cold start: cordis
@@ -240,7 +263,7 @@ export class AcpCompactionEngine extends CompactionEngine {
       systemPrompt.section({
         name: 'billion-context-dsh',
         order: ACP_SYSTEM_PROMPT_ORDER,
-        text: ACP_SYSTEM_PROMPT,
+        text: renderSystemPrompt(this.prompts),
       })
     } else {
       let done = false
@@ -252,7 +275,7 @@ export class AcpCompactionEngine extends CompactionEngine {
         registry.section({
           name: 'billion-context-dsh',
           order: ACP_SYSTEM_PROMPT_ORDER,
-          text: ACP_SYSTEM_PROMPT,
+          text: renderSystemPrompt(this.prompts),
         })
       }
       ctx.on('internal/service', (name: unknown) => {

--- a/src/nudge.ts
+++ b/src/nudge.ts
@@ -18,11 +18,14 @@ import { AcpStateStore } from './state.ts'
 import { allLogMessages, eventsToCoreMessages, surfaceEventsOf } from './messages.ts'
 import { buildCompressibleSeqRanges, findOpenTurn, summarySeqOfKernelBlock, surfaceSummary } from './region.ts'
 import { kernelConfigFor, type KernelConfigInput } from './config.ts'
+import { DEFAULT_RESOLVED, renderTemplate, type ResolvedPrompts } from './prompts.ts'
 
 /** Kernel inputs the nudge path shares with the compress tool. */
 export interface NudgeEnvironment extends KernelConfigInput {
   readonly kernel: CompressionCore
   readonly store: AcpStateStore
+  /** Resolved prompt templates (optional: falls back to DEFAULT_RESOLVED). */
+  readonly prompts?: ResolvedPrompts
 }
 
 export interface NudgeOutcome {
@@ -67,17 +70,28 @@ export function resolveTokenCount(agent: Agent, coreMessages: CoreMessage[]): nu
  * Computed directly from the surface (not the kernel's ref map, which can
  * drift and hide large tool results) — see buildCompressibleSeqRanges.
  */
-export function rangeTable(session: import('@deepseek-ai/dsh-session').Session): string {
+export function rangeTable(
+  session: import('@deepseek-ai/dsh-session').Session,
+  prompts: ResolvedPrompts = DEFAULT_RESOLVED,
+): string {
   const ranges = buildCompressibleSeqRanges(session).slice(0, 6)
+  // 零范围:整块省略(保留现状的提前返回与 nudge 尾部 '\n')。
   if (ranges.length === 0) return ''
-  const lines = ranges.map((range) => `  - seq ${range.start}..${range.end} — ${range.count} messages, ~${range.tokens} tokens`)
+  const lines = ranges.map((range) =>
+    renderTemplate(prompts.rangeTable.line, {
+      start: range.start,
+      end: range.end,
+      count: range.count,
+      tokens: range.tokens,
+    }),
+  )
   return [
+    // 前导空串元素产生 nudge 中范围表前的唯一空行(§4:parts 层不再加分隔)。
     '',
-    `Surface: ${surfaceSummary(session)}`,
-    'Compressible ranges (suggestions only — compress any consumed span; refs are surface seqs):',
+    renderTemplate(prompts.rangeTable.header, { surface: surfaceSummary(session) }),
+    renderTemplate(prompts.rangeTable.title, { count: ranges.length }),
     ...lines,
-    'Compress with: compress({ content: [{ startSeq, endSeq, summary }] }) — content is an array: batch multiple unrelated segments in one call, each entry its own block. Keep ranges disjoint.',
-    'Snapshot taken at nudge time: the seqs go stale once the surface moves (a later compress shadows them), so re-run acp_status for fresh refs before compressing.',
+    prompts.rangeTable.footer,
   ].join('\n')
 }
 
@@ -124,7 +138,7 @@ export function buildNudge(
   if (alreadyShown) return null
   lastNudgeTurn.set(session.id, turnNumber)
 
-  const text = buildNudgeText(nudge, emergency, session)
+  const text = buildNudgeText(nudge, emergency, session, env.prompts)
   const message = createUserMessage({
     content: [{ type: 'text', text }],
     source: { kind: 'plugin', plugin: 'acp-nudge' },
@@ -141,15 +155,19 @@ export function buildNudgeText(
   nudge: NudgeDecision,
   emergency: boolean,
   session: import('@deepseek-ai/dsh-session').Session,
+  prompts: ResolvedPrompts = DEFAULT_RESOLVED,
 ): string {
   // Cap the reported percentage at 100: a broken measurement (e.g. response
   // pressure folded in) must never surface as an absurd "230%" to the model.
   const pct = Math.round(Math.min(nudge.contextUsage, 1) * 100)
-  const frame = emergency
-    ? `⚠️ Context usage is at ${pct}% of the window — nearly full. Consider compressing consumed ranges soon so working context stays available; the choice and timing are yours.`
-    : `Context usage is at ${pct}%. This is a suggestion, not a requirement — you decide whether and when to compress.`
-  const guidance = 'Compress by need, not by percentage: replace only ranges you have genuinely consumed, with dense self-contained summaries.'
-  const parts = [frame, '', guidance]
+  const frame = renderTemplate(
+    emergency ? prompts.nudge.emergency : prompts.nudge.normal,
+    { pct },
+  )
+  // §4 装配规则(逐字节复现现状):frame → guidance(带空行分隔)→ tier(紧跟单换行)
+  // → 范围表(无条件 push,零范围 '' 也 push,保留尾部 '\n')。
+  const parts: string[] = [frame]
+  if (prompts.nudge.guidance !== '') parts.push('', prompts.nudge.guidance)
   if ((nudge.tier === 2 || nudge.tier === 3) && (nudge.tierTargetBlocks?.length ?? 0) > 0) {
     const targets = nudge.tierTargetBlocks!
     const summarySeqs = targets
@@ -157,10 +175,16 @@ export function buildNudgeText(
       .filter((seq): seq is number => seq !== null)
     const pending = nudge.tier === 2 ? nudge.breakdown?.pendingT2 : nudge.breakdown?.pendingT3
     const tokens = typeof pending === 'number' ? pending : 0
-    parts.push(
-      `Tier ${nudge.tier}: ${targets.length} tier-${nudge.tier - 1} block(s) distillable (${tokens} tokens) — compress their summary node(s) [seqs ${summarySeqs.join(', ')}] to reclaim the original messages.`,
-    )
+    const tierLine = renderTemplate(prompts.nudge.tier, {
+      tier: nudge.tier,
+      count: targets.length,
+      prevTier: nudge.tier - 1,
+      tokens,
+      seqs: summarySeqs.join(', '),
+    })
+    // tier 空串 = 删除该行(W1):默认模板恒渲染非空,对默认字节零影响。
+    if (tierLine !== '') parts.push(tierLine)
   }
-  parts.push(rangeTable(session))
+  parts.push(rangeTable(session, prompts))
   return parts.join('\n')
 }

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,0 +1,213 @@
+/**
+ * M4 — configurable prompt templates: the per-stage model-visible texts
+ * (nudge frames, range table, system prompt, tool descriptions) rendered from
+ * `config.prompts` templates with named placeholders.
+ *
+ * Design: docs/configurable-prompts-design.md (v4).
+ * - placeholders are `{identifier}` only; literal braces like
+ *   `compress({ content: [...] })` are left untouched (spaces/commas break the
+ *   identifier rule);
+ * - resolvePrompts merges user overrides over DEFAULT_PROMPTS per key
+ *   (null/undefined → default, string → override; group-level null → whole
+ *   group default for YAML hosts) and validates unknown placeholders at
+ *   construction time (fail-fast, no silent typos);
+ * - renderTemplate throws when a known placeholder has no value — callers
+ *   must provide every value (e.g. tokens via a typeof fallback).
+ * @module billion-context-dsh/prompts
+ */
+
+import { COMPRESS_PHILOSOPHY } from 'acp-kernel'
+
+/** 用户可写值:字符串模板,或 null(= 用默认,等价于不写)。YAML 宿主写 null 是合法输入。 */
+export type PromptInput = string | null
+
+/** 按组生成"每键可选、可 null"的覆盖类型。 */
+export type PromptOverride<T> = { [K in keyof T]?: PromptInput }
+
+export interface NudgePrompts {
+  /** 普通档首句。占位符:{pct} */
+  normal: string
+  /** 紧急档首句。占位符:{pct} */
+  emergency: string
+  /** 指导行。无占位符 */
+  guidance: string
+  /** tier 蒸馏行。占位符:{tier} {count} {prevTier} {tokens} {seqs} */
+  tier: string
+}
+
+export interface RangeTablePrompts {
+  /** 表头。占位符:{surface} */
+  header: string
+  /** 标题。占位符:{count}(表格行数) */
+  title: string
+  /** 每行。占位符:{start} {end} {count} {tokens} */
+  line: string
+  /** 表尾调用语法。无占位符 */
+  footer: string
+}
+
+export interface ToolPrompts {
+  /** 工具描述(纯文本,无占位符) */
+  compress: string
+  decompress: string
+  searchContext: string
+  acpStatus: string
+}
+
+export interface AcpPrompts {
+  readonly nudge?: PromptOverride<NudgePrompts>
+  readonly rangeTable?: PromptOverride<RangeTablePrompts>
+  readonly tools?: PromptOverride<ToolPrompts>
+  /** 整段 system prompt 模板;`{philosophy}` 引用 kernel 的 COMPRESS_PHILOSOPHY */
+  readonly systemPrompt?: PromptInput
+}
+
+/** 解析结果 —— 所有字段已填满(纯 string,无 null)、已校验。构造一次,全程复用。 */
+export interface ResolvedPrompts {
+  readonly nudge: NudgePrompts
+  readonly rangeTable: RangeTablePrompts
+  readonly tools: ToolPrompts
+  /** 注意:这是【模板】(含 {philosophy}),不是渲染结果。渲染用 renderSystemPrompt。 */
+  readonly systemPromptTemplate: string
+}
+
+/** 每槽允许的占位符名集合(构建期校验用)。 */
+const NUDGE_ALLOWED: { [K in keyof NudgePrompts]: ReadonlySet<string> } = {
+  normal: new Set(['pct']),
+  emergency: new Set(['pct']),
+  guidance: new Set(),
+  tier: new Set(['tier', 'count', 'prevTier', 'tokens', 'seqs']),
+}
+const RANGE_TABLE_ALLOWED: { [K in keyof RangeTablePrompts]: ReadonlySet<string> } = {
+  header: new Set(['surface']),
+  title: new Set(['count']),
+  line: new Set(['start', 'end', 'count', 'tokens']),
+  footer: new Set(),
+}
+const TOOLS_ALLOWED: { [K in keyof ToolPrompts]: ReadonlySet<string> } = {
+  compress: new Set(),
+  decompress: new Set(),
+  searchContext: new Set(),
+  acpStatus: new Set(),
+}
+const SYSTEM_ALLOWED = new Set(['philosophy'])
+
+/** 校验单个模板:未知 `{ident}` → throw(带槽位路径)。默认模板开发期已核验,不重扫。 */
+function validateTemplate(template: string, allowed: ReadonlySet<string>, path: string): string {
+  const re = /\{([A-Za-z_][A-Za-z0-9_]*)\}/g
+  let match: RegExpExecArray | null
+  while ((match = re.exec(template)) !== null) {
+    const name = match[1]!
+    if (!allowed.has(name)) {
+      throw new Error(
+        `${path} contains unknown placeholder {${name}} — allowed: ${[...allowed].join(', ') || '(none)'}`,
+      )
+    }
+  }
+  return template
+}
+
+/**
+ * 纯替换。两个契约:
+ * 1. 未知占位符不可能到达这里(构建期已校验);
+ * 2. 已知占位符缺值 = 编程错误 → throw(绝不静默渲染空串)。
+ */
+export function renderTemplate(template: string, vars: Record<string, string | number>): string {
+  return template.replace(/\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (_match, name: string) => {
+    const value = vars[name]
+    if (value === undefined) {
+      throw new Error(
+        `renderTemplate: missing value for placeholder {${name}} in template "${template.slice(0, 60)}…"`,
+      )
+    }
+    return String(value)
+  })
+}
+
+/**
+ * 逐键合并:null / undefined → 默认;字符串 → 覆盖默认(不用 spread,
+ * 否则 null 会覆盖默认,与"null = 用默认"矛盾)。组级 null/undefined →
+ * 整组用默认(YAML 宿主可能写 `{ nudge: null }`,W3)。
+ */
+function mergeGroup<T extends Record<keyof T, string>>(
+  defaults: T,
+  override: PromptOverride<T> | null | undefined,
+  allowed: { [K in keyof T]: ReadonlySet<string> },
+  path: string,
+): T {
+  if (override == null) return defaults
+  const out = {} as { [K in keyof T]: string }
+  for (const key of Object.keys(defaults) as Array<keyof T>) {
+    const value = override[key]
+    out[key] = value === null || value === undefined
+      ? defaults[key]
+      : validateTemplate(value, allowed[key], `${path}.${String(key)}`)
+  }
+  return out as T
+}
+
+/**
+ * 深合并 + 校验;引擎构造期调用一次,出错即抛(fail-fast)。
+ * 未传入时返回 DEFAULT_RESOLVED,零校验重跑。
+ */
+export function resolvePrompts(input?: AcpPrompts): ResolvedPrompts {
+  if (input === undefined) return DEFAULT_RESOLVED
+  return {
+    nudge: mergeGroup(DEFAULT_PROMPTS.nudge, input.nudge, NUDGE_ALLOWED, 'prompts.nudge'),
+    rangeTable: mergeGroup(DEFAULT_PROMPTS.rangeTable, input.rangeTable, RANGE_TABLE_ALLOWED, 'prompts.rangeTable'),
+    tools: mergeGroup(DEFAULT_PROMPTS.tools, input.tools, TOOLS_ALLOWED, 'prompts.tools'),
+    systemPromptTemplate:
+      input.systemPrompt === null || input.systemPrompt === undefined
+        ? DEFAULT_PROMPTS.systemPromptTemplate
+        : validateTemplate(input.systemPrompt, SYSTEM_ALLOWED, 'prompts.systemPrompt'),
+  }
+}
+
+/** 渲染 system prompt 模板(注入 kernel 压缩哲学)。 */
+export function renderSystemPrompt(prompts: ResolvedPrompts): string {
+  return renderTemplate(prompts.systemPromptTemplate, { philosophy: COMPRESS_PHILOSOPHY })
+}
+
+/**
+ * 默认模板 —— 与 v4 之前的硬编码文案逐字节一致
+ * (回归锚点见 tests/prompts.test.ts 的硬编码字面量快照)。
+ */
+export const DEFAULT_PROMPTS: ResolvedPrompts = {
+  nudge: {
+    normal: 'Context usage is at {pct}%. This is a suggestion, not a requirement — you decide whether and when to compress.',
+    emergency: '⚠️ Context usage is at {pct}% of the window — nearly full. Consider compressing consumed ranges soon so working context stays available; the choice and timing are yours.',
+    guidance: 'Compress by need, not by percentage: replace only ranges you have genuinely consumed, with dense self-contained summaries.',
+    tier: 'Tier {tier}: {count} tier-{prevTier} block(s) distillable ({tokens} tokens) — compress their summary node(s) [seqs {seqs}] to reclaim the original messages.',
+  },
+  rangeTable: {
+    header: 'Surface: {surface}',
+    title: 'Compressible ranges (suggestions only — compress any consumed span; refs are surface seqs):',
+    line: '  - seq {start}..{end} — {count} messages, ~{tokens} tokens',
+    footer: 'Compress with: compress({ content: [{ startSeq, endSeq, summary }] }) — content is an array: batch multiple unrelated segments in one call, each entry its own block. Keep ranges disjoint.\n'
+      + 'Snapshot taken at nudge time: the seqs go stale once the surface moves (a later compress shadows them), so re-run acp_status for fresh refs before compressing.',
+  },
+  tools: {
+    compress: 'Replace older conversation ranges with dense summaries you write. Each message seq is a surface reference. Single range: compress({ content: [{ startSeq, endSeq, summary }] }). Batch multiple unrelated ranges in one call (each content entry becomes its own block); keep ranges disjoint. Never compress content the current step is actively using. Seq refs must come from the CURRENT surface (acp_status or the latest nudge): a span whose edges were shadowed by an earlier compress is auto-remapped to its still-live content, a fully compressed span is reported as already compressed, and invented/other-session seqs fail with guidance.',
+    decompress: 'Recover the original content of a compressed block by its blockId (read-only; does not unshadow the range).',
+    searchContext: 'Search inside compressed blocks (summaries and original content) for information the model no longer sees in context.',
+    acpStatus: 'Report the ACP block ledger: compressed blocks, reclaimed tokens, and current context pressure.',
+  },
+  systemPromptTemplate: `Active Context Pruning — model-driven context management
+
+YOU decide whether and when to compress context. Nothing forces you: the injected "nudge" is a suggestion, not an order, and you may ignore it when compression would not help. Compress only ranges you have genuinely consumed (read tool outputs, finished explorations, superseded steps) that the current work no longer needs verbatim.
+
+{philosophy}
+
+Compression tools (refs are SURFACE SEQS, not ids):
+- compress: replace one or more seq ranges, each with your own dense summary. Single range: compress({ content: [{ startSeq, endSeq, summary }] }). Batch multiple unrelated segments in one call (each entry becomes its own block): compress({ content: [{ startSeq: 1, endSeq: 5, summary: '...' }, { startSeq: 12, endSeq: 18, summary: '...' }] }). Keep ranges disjoint — overlapping entries in one batch are skipped. Edges are auto-balanced to tool-call/result boundaries; a trailing #callId fragment in a seq is ignored. Seq refs must be on the current surface: seqs from older nudges or earlier compresses go stale as the surface moves, so a stale span is auto-remapped to its still-live remainder (the result reports the adjusted span), a fully compressed span is reported as already compressed, and invented/other-session seqs fail with guidance.
+- decompress: recover a compressed block's original content, read-only. decompress({ blockId }).
+- search_context: find information inside compressed blocks BEFORE decompressing. search_context({ query }).
+- acp_status: current context usage and the live compressible-range list. Run it right before compressing — the only seqs that never go stale are the ones you just read.
+
+Tiered compression: each compressed block appears on the surface as one summary node. Compressing that node again DISTILLS the block (tier 2): the parent summary folds into your new summary and the original messages are freed. Distilling a tier-2 block yields tier 3. Distill when a summary itself is consumed — decompress on the tier-2 block recovers the full originals.
+
+When you write a summary, it becomes the ONLY record of that range: keep file paths, signatures, exact values, decisions, and error strings verbatim so a later reader (or you, after decompress) can continue without the original. Never reuse historical seqs — the surface moves as messages land and compress; verify with acp_status.`,
+}
+
+/** 模块级默认缓存:默认参/兜底直接引用,避免每次调用重跑校验。 */
+export const DEFAULT_RESOLVED: ResolvedPrompts = DEFAULT_PROMPTS

--- a/src/system-prompt.ts
+++ b/src/system-prompt.ts
@@ -4,26 +4,16 @@
  * instead of being re-sent with every nudge. The nudge itself stays a short,
  * advisory notice — ACP is model-driven, the model decides whether and when
  * to compress (never "compress now").
+ *
+ * The text is DEFAULT_PROMPTS.systemPromptTemplate rendered with the kernel's
+ * COMPRESS_PHILOSOPHY; hosts can override the whole section via
+ * `config.prompts.systemPrompt` (see docs/configurable-prompts-design.md).
  * @module billion-context-dsh/system-prompt
  */
 
-import { COMPRESS_PHILOSOPHY } from 'acp-kernel'
+import { DEFAULT_PROMPTS, renderSystemPrompt } from './prompts.ts'
 
-export const ACP_SYSTEM_PROMPT = `Active Context Pruning — model-driven context management
-
-YOU decide whether and when to compress context. Nothing forces you: the injected "nudge" is a suggestion, not an order, and you may ignore it when compression would not help. Compress only ranges you have genuinely consumed (read tool outputs, finished explorations, superseded steps) that the current work no longer needs verbatim.
-
-${COMPRESS_PHILOSOPHY}
-
-Compression tools (refs are SURFACE SEQS, not ids):
-- compress: replace one or more seq ranges, each with your own dense summary. Single range: compress({ content: [{ startSeq, endSeq, summary }] }). Batch multiple unrelated segments in one call (each entry becomes its own block): compress({ content: [{ startSeq: 1, endSeq: 5, summary: '...' }, { startSeq: 12, endSeq: 18, summary: '...' }] }). Keep ranges disjoint — overlapping entries in one batch are skipped. Edges are auto-balanced to tool-call/result boundaries; a trailing #callId fragment in a seq is ignored. Seq refs must be on the current surface: seqs from older nudges or earlier compresses go stale as the surface moves, so a stale span is auto-remapped to its still-live remainder (the result reports the adjusted span), a fully compressed span is reported as already compressed, and invented/other-session seqs fail with guidance.
-- decompress: recover a compressed block's original content, read-only. decompress({ blockId }).
-- search_context: find information inside compressed blocks BEFORE decompressing. search_context({ query }).
-- acp_status: current context usage and the live compressible-range list. Run it right before compressing — the only seqs that never go stale are the ones you just read.
-
-Tiered compression: each compressed block appears on the surface as one summary node. Compressing that node again DISTILLS the block (tier 2): the parent summary folds into your new summary and the original messages are freed. Distilling a tier-2 block yields tier 3. Distill when a summary itself is consumed — decompress on the tier-2 block recovers the full originals.
-
-When you write a summary, it becomes the ONLY record of that range: keep file paths, signatures, exact values, decisions, and error strings verbatim so a later reader (or you, after decompress) can continue without the original. Never reuse historical seqs — the surface moves as messages land and compress; verify with acp_status.`
+export const ACP_SYSTEM_PROMPT = renderSystemPrompt(DEFAULT_PROMPTS)
 
 /** System-prompt section order: tool guidance lives in 100–199. */
 export const ACP_SYSTEM_PROMPT_ORDER = 150

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -30,12 +30,15 @@ import {
   type ResolvedSurfaceRange,
 } from './region.ts'
 import { allLogMessages, eventsToCoreMessages, extractEventText, surfaceEventsOf } from './messages.ts'
+import { DEFAULT_RESOLVED, type ResolvedPrompts } from './prompts.ts'
 
 export interface ToolEnvironment extends KernelConfigInput {
   readonly kernel: CompressionCore
   readonly store: AcpStateStore
   /** Resolve the effective context window for an agent (optional: status falls back to modelContextLimit). */
   readonly windowFor?: (agent: Agent) => Promise<AcpWindow>
+  /** Resolved prompt templates (optional: falls back to DEFAULT_RESOLVED). */
+  readonly prompts?: ResolvedPrompts
 }
 
 interface TextOutput {
@@ -396,17 +399,11 @@ async function handleStatus(env: ToolEnvironment, _args: StatusArgs, exec: ToolR
 
 /** Build the four ACP model tools bound to one engine. */
 export function makeTools(env: ToolEnvironment): ToolDefinition[] {
+  const prompts = env.prompts ?? DEFAULT_RESOLVED
   return [
     defineTool({
       name: 'compress',
-      description:
-        'Replace older conversation ranges with dense summaries you write. '
-        + 'Each message seq is a surface reference. Single range: compress({ content: [{ startSeq, endSeq, summary }] }). '
-        + 'Batch multiple unrelated ranges in one call (each content entry becomes its own block); keep ranges disjoint. '
-        + 'Never compress content the current step is actively using. '
-        + 'Seq refs must come from the CURRENT surface (acp_status or the latest nudge): a span whose edges were shadowed '
-        + 'by an earlier compress is auto-remapped to its still-live content, a fully compressed span is reported as '
-        + 'already compressed, and invented/other-session seqs fail with guidance.',
+      description: prompts.tools.compress,
       parameters: compressParameters,
       output: textOutput(),
       async execute(args, exec) {
@@ -415,7 +412,7 @@ export function makeTools(env: ToolEnvironment): ToolDefinition[] {
     }),
     defineTool({
       name: 'decompress',
-      description: 'Recover the original content of a compressed block by its blockId (read-only; does not unshadow the range).',
+      description: prompts.tools.decompress,
       parameters: decompressParameters,
       output: textOutput(),
       execute(args, exec) {
@@ -424,7 +421,7 @@ export function makeTools(env: ToolEnvironment): ToolDefinition[] {
     }),
     defineTool({
       name: 'search_context',
-      description: 'Search inside compressed blocks (summaries and original content) for information the model no longer sees in context.',
+      description: prompts.tools.searchContext,
       parameters: searchParameters,
       output: textOutput(),
       execute(args, exec) {
@@ -433,7 +430,7 @@ export function makeTools(env: ToolEnvironment): ToolDefinition[] {
     }),
     defineTool({
       name: 'acp_status',
-      description: 'Report the ACP block ledger: compressed blocks, reclaimed tokens, and current context pressure.',
+      description: prompts.tools.acpStatus,
       parameters: statusParameters,
       output: textOutput(),
       execute(args, exec) {

--- a/tests/prompts.test.ts
+++ b/tests/prompts.test.ts
@@ -1,0 +1,252 @@
+/**
+ * M4 — configurable prompts: template rendering, per-key merge + validation,
+ * and byte-identical default snapshots (the anti-regression anchor for the
+ * template migration — literals below were captured from the PRE-change
+ * implementation, so they are independent of the new rendering code).
+ * Design: docs/configurable-prompts-design.md (v4).
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { Context } from '@deepseek-ai/cordis'
+import { createCore, type CompressionCore, type NudgeDecision } from 'acp-kernel'
+import type { Agent } from '@deepseek-ai/dsh-agent'
+import { AcpStateStore } from '../src/state.ts'
+import { buildNudge, buildNudgeText, rangeTable, type NudgeEnvironment } from '../src/nudge.ts'
+import { makeTools, type ToolEnvironment } from '../src/tools.ts'
+import {
+  DEFAULT_PROMPTS,
+  renderSystemPrompt,
+  renderTemplate,
+  resolvePrompts,
+} from '../src/prompts.ts'
+import { buildTextSession } from './helpers.ts'
+
+function fakeAgent(session: import('@deepseek-ai/dsh-session').Session): Agent {
+  return {
+    id: session.id,
+    session,
+    options: { provider: 'test-provider', model: 'test-model' },
+    ctx: new Context(),
+  } as unknown as Agent
+}
+
+function makeEnv(limit: number): ToolEnvironment {
+  return {
+    kernel: createCore({}) as CompressionCore,
+    store: new AcpStateStore(),
+    modelContextLimit: limit,
+  }
+}
+
+function fakeDecision(pct: number, emergency: boolean): NudgeDecision {
+  return {
+    shouldInject: true,
+    reason: 'probe',
+    compressibleRanges: [],
+    tierTargetBlocks: [],
+    contextUsage: pct / 100,
+    tier: null,
+    breakdown: {
+      usage: pct / 100,
+      growth: 0,
+      growthReference: 0,
+      effectiveThreshold: 0,
+      nudgeGrowthTokens: 50000,
+      growthFloor: 20000,
+      hasPendingNudge: 0,
+      overLimit: emergency ? 1 : 0,
+      emergencyOverride: emergency ? 1 : 0,
+      pendingT1: 0,
+      pendingT2: 0,
+      pendingT3: 0,
+    },
+  } as never
+}
+
+/** 快照 1:改造前 ACP_SYSTEM_PROMPT 的逐字节字面量(与实现分离,防循环论证)。 */
+const SYSTEM_PROMPT_SNAPSHOT = `Active Context Pruning — model-driven context management
+
+YOU decide whether and when to compress context. Nothing forces you: the injected "nudge" is a suggestion, not an order, and you may ignore it when compression would not help. Compress only ranges you have genuinely consumed (read tool outputs, finished explorations, superseded steps) that the current work no longer needs verbatim.
+
+Compression Philosophy:
+- All compression serves the primary task, but be frugal.
+- Context capacity is precious. Save context by compressing consumed outputs, not by avoiding tools.
+- Compress by need, not by percentage.
+- Work from summaries, not raw tool outputs. All listed ranges (user prompts, tool outputs, code, logs, exploration, intermediate steps) should be compressed to summary format — the ONLY exceptions are protected content, content the current step is actively using, or critical content you cannot reconstruct.
+
+Compression tools (refs are SURFACE SEQS, not ids):
+- compress: replace one or more seq ranges, each with your own dense summary. Single range: compress({ content: [{ startSeq, endSeq, summary }] }). Batch multiple unrelated segments in one call (each entry becomes its own block): compress({ content: [{ startSeq: 1, endSeq: 5, summary: '...' }, { startSeq: 12, endSeq: 18, summary: '...' }] }). Keep ranges disjoint — overlapping entries in one batch are skipped. Edges are auto-balanced to tool-call/result boundaries; a trailing #callId fragment in a seq is ignored. Seq refs must be on the current surface: seqs from older nudges or earlier compresses go stale as the surface moves, so a stale span is auto-remapped to its still-live remainder (the result reports the adjusted span), a fully compressed span is reported as already compressed, and invented/other-session seqs fail with guidance.
+- decompress: recover a compressed block's original content, read-only. decompress({ blockId }).
+- search_context: find information inside compressed blocks BEFORE decompressing. search_context({ query }).
+- acp_status: current context usage and the live compressible-range list. Run it right before compressing — the only seqs that never go stale are the ones you just read.
+
+Tiered compression: each compressed block appears on the surface as one summary node. Compressing that node again DISTILLS the block (tier 2): the parent summary folds into your new summary and the original messages are freed. Distilling a tier-2 block yields tier 3. Distill when a summary itself is consumed — decompress on the tier-2 block recovers the full originals.
+
+When you write a summary, it becomes the ONLY record of that range: keep file paths, signatures, exact values, decisions, and error strings verbatim so a later reader (or you, after decompress) can continue without the original. Never reuse historical seqs — the surface moves as messages land and compress; verify with acp_status.`
+
+test('M4/prompts 1: default system prompt renders byte-identical to the pre-change literal', () => {
+  assert.equal(renderSystemPrompt(resolvePrompts()), SYSTEM_PROMPT_SNAPSHOT)
+})
+
+test('M4/prompts 2: default normal nudge snapshot — zero-range session, trailing newline is part of the bytes', () => {
+  const text = buildNudgeText(fakeDecision(7, false), false, buildTextSession(4))
+  assert.equal(
+    text,
+    'Context usage is at 7%. This is a suggestion, not a requirement — you decide whether and when to compress.\n\n'
+      + 'Compress by need, not by percentage: replace only ranges you have genuinely consumed, with dense self-contained summaries.\n',
+  )
+})
+
+test('M4/prompts 3: default emergency nudge snapshot — ⚠️ frame, trailing newline', () => {
+  const text = buildNudgeText(fakeDecision(96, true), true, buildTextSession(4))
+  assert.equal(
+    text,
+    '⚠️ Context usage is at 96% of the window — nearly full. Consider compressing consumed ranges soon so working context stays available; the choice and timing are yours.\n\n'
+      + 'Compress by need, not by percentage: replace only ranges you have genuinely consumed, with dense self-contained summaries.\n',
+  )
+})
+
+test('M4/prompts 4: range table snapshot (with ranges) and zero-range early return', () => {
+  assert.equal(rangeTable(buildTextSession(4)), '')
+  assert.equal(
+    rangeTable(buildTextSession(12)),
+    `\nSurface: 12 nodes, seqs 1..12
+Compressible ranges (suggestions only — compress any consumed span; refs are surface seqs):
+  - seq 1..7 — 7 messages, ~7227 tokens
+Compress with: compress({ content: [{ startSeq, endSeq, summary }] }) — content is an array: batch multiple unrelated segments in one call, each entry its own block. Keep ranges disjoint.
+Snapshot taken at nudge time: the seqs go stale once the surface moves (a later compress shadows them), so re-run acp_status for fresh refs before compressing.`,
+  )
+})
+
+test('M4/prompts 5: tool descriptions render the defaults byte-identical', () => {
+  const descriptions = Object.fromEntries(makeTools(makeEnv(128000)).map((t) => [t.name, t.description]))
+  assert.equal(
+    descriptions['compress'],
+    'Replace older conversation ranges with dense summaries you write. Each message seq is a surface reference. Single range: compress({ content: [{ startSeq, endSeq, summary }] }). Batch multiple unrelated ranges in one call (each content entry becomes its own block); keep ranges disjoint. Never compress content the current step is actively using. Seq refs must come from the CURRENT surface (acp_status or the latest nudge): a span whose edges were shadowed by an earlier compress is auto-remapped to its still-live content, a fully compressed span is reported as already compressed, and invented/other-session seqs fail with guidance.',
+  )
+  assert.equal(descriptions['decompress'], 'Recover the original content of a compressed block by its blockId (read-only; does not unshadow the range).')
+  assert.equal(descriptions['search_context'], 'Search inside compressed blocks (summaries and original content) for information the model no longer sees in context.')
+  assert.equal(descriptions['acp_status'], 'Report the ACP block ledger: compressed blocks, reclaimed tokens, and current context pressure.')
+})
+
+test('M4/prompts 6: partial overrides merge per key; key/group null falls back to default', () => {
+  const merged = resolvePrompts({ nudge: { normal: '自定义 {pct}' } })
+  assert.equal(merged.nudge.normal, '自定义 {pct}')
+  assert.equal(merged.nudge.emergency, DEFAULT_PROMPTS.nudge.emergency)
+  const keyNull = resolvePrompts({ nudge: { guidance: null } })
+  assert.equal(keyNull.nudge.guidance, DEFAULT_PROMPTS.nudge.guidance)
+  const groupNull = resolvePrompts({ nudge: null } as never)
+  assert.equal(groupNull.nudge, DEFAULT_PROMPTS.nudge)
+})
+
+test('M4/prompts 7: nudge normal template substitutes {pct}', () => {
+  const prompts = resolvePrompts({ nudge: { normal: '上下文使用率 {pct}%' } })
+  const text = buildNudgeText(fakeDecision(7, false), false, buildTextSession(4), prompts)
+  assert.ok(text.startsWith('上下文使用率 7%'))
+})
+
+test('M4/prompts 8: unknown placeholder throws with the slot path', () => {
+  assert.throws(
+    () => resolvePrompts({ nudge: { normal: '…{pctt}…' } }),
+    /prompts\.nudge\.normal contains unknown placeholder \{pctt\}/,
+  )
+  assert.throws(
+    () => resolvePrompts({ rangeTable: { line: '  - {start}..{wrong}' } }),
+    /prompts\.rangeTable\.line contains unknown placeholder \{wrong\}/,
+  )
+  assert.throws(
+    () => resolvePrompts({ systemPrompt: 'x {philosophyy} y' }),
+    /prompts\.systemPrompt contains unknown placeholder \{philosophyy\}/,
+  )
+})
+
+test('M4/prompts 9: renderTemplate throws on a missing value for a known placeholder', () => {
+  assert.throws(
+    () => renderTemplate('{tokens} tokens', {}),
+    /missing value for placeholder \{tokens\}/,
+  )
+})
+
+test('M4/prompts 10: empty guidance removes the line cleanly (frame + newline + table)', () => {
+  const session = buildTextSession(12)
+  const prompts = resolvePrompts({ nudge: { guidance: '' } })
+  const frame = 'Context usage is at 7%. This is a suggestion, not a requirement — you decide whether and when to compress.'
+  const text = buildNudgeText(fakeDecision(7, false), false, session, prompts)
+  assert.equal(text, `${frame}\n${rangeTable(session)}`)
+  assert.ok(!text.includes('Compress by need'))
+})
+
+test('M4/prompts 11: tier line renders (0 tokens) when pending is missing (B2 fallback)', () => {
+  const decision: NudgeDecision = {
+    shouldInject: true,
+    reason: 'tier-2 distillation recommended',
+    compressibleRanges: [],
+    tierTargetBlocks: [{ blockId: 'b1' } as never],
+    contextUsage: 0.9,
+    tier: 2,
+    // pendingT2 deliberately absent at runtime: NudgeBreakdown requires it
+    // statically (acp-kernel types.d.ts:183-185), so cast per test convention.
+    breakdown: {
+      usage: 0.9,
+      growth: 0,
+      growthReference: 0,
+      effectiveThreshold: 0,
+      nudgeGrowthTokens: 50000,
+      growthFloor: 20000,
+      hasPendingNudge: 0,
+      overLimit: 1,
+      emergencyOverride: 0,
+      pendingT1: 0,
+      pendingT3: 0,
+    } as never,
+  }
+  const text = buildNudgeText(decision, false, buildTextSession(12))
+  assert.match(text, /Tier 2: 1 tier-1 block\(s\) distillable \(0 tokens\)/)
+  assert.doesNotMatch(text, /\( tokens\)/)
+})
+
+test('M4/prompts 12: buildNudge forwards env.prompts into the injected message (B1)', () => {
+  const env: NudgeEnvironment = {
+    kernel: createCore({}) as CompressionCore,
+    store: new AcpStateStore(),
+    // ~77.5% usage for 12 messages: over-limit (>= 0.70) but below emergency
+    // (0.85) → the NORMAL frame renders.
+    modelContextLimit: 16000,
+    prompts: resolvePrompts({ nudge: { normal: 'CUSTOM normal {pct}' } }),
+  }
+  const outcome = buildNudge(fakeAgent(buildTextSession(12)), env, new Map<string, number>())
+  assert.ok(outcome !== null, 'over-limit nudge fires')
+  assert.equal(outcome!.emergency, false)
+  const text = outcome!.message.content.map((block) => (block as { text?: string }).text ?? '').join('')
+  assert.ok(text.startsWith('CUSTOM normal '), 'the custom normal frame reached the injected message')
+})
+
+test('M4/prompts 13: Chinese override smoke (i18n scenario)', () => {
+  const prompts = resolvePrompts({
+    nudge: {
+      normal: '上下文使用率 {pct}%。这是建议,不是要求 —— 是否压缩、何时压缩,由你决定。',
+      emergency: '⚠️ 上下文使用率已达窗口的 {pct}% —— 几乎满了。',
+      guidance: '按需压缩,而不是按百分比:只替换你真正消费过的范围。',
+      tier: '第 {tier} 层:{count} 个第 {prevTier} 层块可蒸馏({tokens} tokens)。',
+    },
+    rangeTable: {
+      header: '表面:{surface}',
+      title: '可压缩范围(仅供参考):',
+      line: '  - seq {start}..{end} — {count} 条消息,约 {tokens} tokens',
+      footer: '用 compress 压缩;批量条目各成一个块。',
+    },
+    systemPrompt: '主动上下文剪枝 —— 模型驱动。\n{philosophy}\n压缩工具:compress/decompress/search_context/acp_status。',
+  })
+  const session = buildTextSession(12)
+  const text = buildNudgeText(fakeDecision(7, false), false, session, prompts)
+  assert.ok(text.includes('上下文使用率 7%'))
+  assert.ok(text.includes('表面:12 nodes, seqs 1..12'))
+  assert.ok(text.includes('可压缩范围(仅供参考):'))
+  const emerg = buildNudgeText(fakeDecision(96, true), true, session, prompts)
+  assert.ok(emerg.includes('已达窗口的 96%'))
+  const sys = renderSystemPrompt(prompts)
+  assert.ok(sys.includes('主动上下文剪枝'))
+  assert.ok(sys.includes('Compression Philosophy:'))
+  assert.ok(sys.includes('compress/decompress/search_context/acp_status'))
+})

--- a/tests/prompts.test.ts
+++ b/tests/prompts.test.ts
@@ -21,6 +21,7 @@ import {
   resolvePrompts,
 } from '../src/prompts.ts'
 import { buildTextSession } from './helpers.ts'
+import AcpCompactionEngine, { AcpCompactionEngine as Named } from '../src/index.ts'
 
 function fakeAgent(session: import('@deepseek-ai/dsh-session').Session): Agent {
   return {
@@ -249,4 +250,55 @@ test('M4/prompts 13: Chinese override smoke (i18n scenario)', () => {
   assert.ok(sys.includes('主动上下文剪枝'))
   assert.ok(sys.includes('Compression Philosophy:'))
   assert.ok(sys.includes('compress/decompress/search_context/acp_status'))
+})
+
+test('M4/prompts 14: engine-level — config.prompts reaches system prompt section, tool descriptions, and the pre-step nudge', async () => {
+  const ctx = new Context()
+  const sections: Array<{ name: string; order: number; text: string }> = []
+  const tools: Array<{ name: string; description: string }> = []
+  ctx.provide('systemPrompt' as never, { section: (opts: never) => sections.push(opts as never) } as never)
+  ctx.provide('tools' as never, { register: (tool: never) => tools.push(tool as never) } as never)
+  ctx.plugin(AcpCompactionEngine as never, {
+    modelContextLimit: 16000,
+    prompts: {
+      nudge: { normal: '引擎级自定义 {pct}' },
+      systemPrompt: '引擎级系统提示\n{philosophy}',
+      tools: { compress: '引擎级压缩工具描述' },
+    },
+  } as never)
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  const engine = ctx.compaction as Named
+  assert.ok(engine instanceof Named)
+  assert.equal(engine.prompts.nudge.normal, '引擎级自定义 {pct}', 'engine resolved the custom template')
+
+  // System prompt section: rendered once with the custom template + kernel philosophy.
+  assert.equal(sections.length, 1, 'ACP section registered exactly once')
+  assert.ok(sections[0]!.text.includes('引擎级系统提示'))
+  assert.ok(sections[0]!.text.includes('Compression Philosophy:'), 'kernel philosophy embedded via {philosophy}')
+
+  // Tool descriptions: registered from env.prompts (proves env carried this.prompts).
+  const compressTool = tools.find((t) => t.name === 'compress')
+  assert.equal(compressTool!.description, '引擎级压缩工具描述')
+
+  // pre-step: the custom normal frame reaches the injected nudge message.
+  const decision = await (ctx.waterfall(
+    'agent/pre-step' as never,
+    { agent: fakeAgent(buildTextSession(12)) } as never,
+    async () => ({ kind: 'enter', messages: [] }) as never,
+  ) as never)
+  const decisionObj = decision as { kind: string; messages: Array<{ content: Array<{ type: string; text?: string }> }> }
+  assert.equal(decisionObj.kind, 'enter')
+  assert.equal(decisionObj.messages.length, 1, 'the nudge message was appended to the decision')
+  const text = decisionObj.messages[0]!.content.map((block) => block.text ?? '').join('')
+  assert.ok(text.startsWith('引擎级自定义 '), 'the custom nudge frame reached the injected message')
+})
+
+test('M4/prompts 15: engine construction fails fast on a template typo', () => {
+  assert.throws(
+    () => new Named(new Context(), { prompts: { nudge: { normal: '{bad}' } } }),
+    /prompts\.nudge\.normal contains unknown placeholder \{bad\}/,
+  )
+  // Group-level null from YAML-ish input is tolerated (whole group falls back).
+  const engine = new Named(new Context(), { prompts: { nudge: null } } as never)
+  assert.equal(engine.prompts.nudge.normal, DEFAULT_PROMPTS.nudge.normal)
 })


### PR DESCRIPTION
## 功能

通过宿主 composition 的 `config.prompts` 字段，按阶段覆盖**所有模型可见提示词**：nudge 普通/紧急档首句、tier 蒸馏行、范围表、ACP system prompt 段、四个工具描述。模板 + 命名占位符（如 `{pct}`/`{surface}`），**构造期 fail-fast 校验**（占位符拼写错误启动即抛，而非漏进模型上下文）。

- 新文件 `src/prompts.ts`：`AcpPrompts` 类型 + `DEFAULT_PROMPTS`（默认文案与现有输出逐字节一致）+ `resolvePrompts`（逐键合并、组级 null 归一化）+ `renderTemplate`（缺值即抛）+ `renderSystemPrompt`（注入 kernel `COMPRESS_PHILOSOPHY`）
- 接线：`AcpConfig.prompts` → `env.prompts` 转发 → nudge 装配 / 四工具描述 / system prompt section
- 基于 main v0.1.8（rebase）：与 stale-seq 恢复、projectedTokens 文案完全兼容

## 测试

- 新增 15 条（`tests/prompts.test.ts`）：13 条单元（硬编码字面量快照、深合并 + null 归一化、占位符替换、未知占位符抛错、空串删除、tokens 兜底、中文 i18n）+ 2 条引擎级（挂载/接线、fail-fast）
- 全量 **77/77 通过**，`npm run typecheck` / `npm run build` 干净

## 实机验证

headless + web GUI 双端实测：引擎挂载、四工具注册、ACP system prompt 段落注入、`config.prompts` 覆盖逐字生效（FEAT-VERIFY 标记验证后已回滚恢复默认）。

## 文档同步（本 PR 内完成）

- `README.md` / `README.en.md`：新增「自定义提示词文案 — `config.prompts`」小节 + 配置表 `prompts` 行
- `docs/INSTALL.md`：2a 组合行加可选 `prompts` 配置说明
- `docs/configurable-prompts-design.md`：§5 默认值同步 main v0.1.8 文案；§8 测试计划注明 15 条

## AGENTS.md 修改

新增两条开发规范（§4 Development standards）：

> - **Docs must stay in sync with every PR** — before opening a PR, review the diff against the documentation: any behavior the change alters must match what the docs describe, and docs that state the old behavior must be updated in the same PR. A PR that changes behavior without touching docs is incomplete.
> - **Feature work MUST document itself** — every feature (any behavior addition or change) must add an explanation of the new capability in the relevant docs: user-facing config/options in `README.md` / `README.en.md`, install-time composition options in `docs/INSTALL.md`, design decisions in `docs/*-design.md`, and the module map / hard-won rules in `AGENTS.md` itself. Precedent: the `config.prompts` feature shipped its README section, INSTALL note, config table row, and design doc in the same PR.

即：每次提交 PR 前检查修改与文档的一致性；功能修改必须在相关文档对应位置加入说明。本次 PR 的文档同步即按此规则自查补全，并作为先例锚定。
