### PR TITLE
(chore) bump acp-kernel 0.0.23 → 0.0.24

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ Design decisions (see docs/dsh-porting-verification.md for the full evidence):
 2. **Seq is the ref** — no `<acp>` tags; the nudge's range table carries surface seqs.
 3. **No automatic summarization** — `compactIfNeeded` returns null; nudges are advisory, never imperative ("the choice and timing are yours").
 4. **Model-driven summaries** — the model writes the summary via `compress`; no second LLM summarization call.
-5. **`acp-kernel` pinned to an exact version** (e.g. `"acp-kernel": "0.0.23"`, NEVER `^`). It is inlined by tsup; a caret range breaks reproducibility.
+5. **`acp-kernel` pinned to an exact version** (e.g. `"acp-kernel": "0.0.24"`, NEVER `^`). It is inlined by tsup; a caret range breaks reproducibility.
 
 ## 3. Hard-won rules (from v0.1.1 long-session battle)
 
@@ -83,7 +83,7 @@ The PR title is enforced by CI (`.github/workflows/pr-lint.yml` → `scripts/che
 
 ## 4b. acp-kernel upgrade policy (the kernel WILL move on)
 
-`acp-kernel` is pinned **exactly** (e.g. `0.0.23`, never `^`) because tsup inlines it — a caret range makes the resolved version drift when the lockfile regenerates, breaking reproducible builds. But pinning is **not** freezing: upgrades are a controlled, manual process.
+`acp-kernel` is pinned **exactly** (e.g. `0.0.24`, never `^`) because tsup inlines it — a caret range makes the resolved version drift when the lockfile regenerates, breaking reproducible builds. But pinning is **not** freezing: upgrades are a controlled, manual process.
 
 **When to check:** on any feature work, or monthly — `npm view acp-kernel version`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.8",
 			"license": "MIT",
 			"dependencies": {
-				"acp-kernel": "0.0.23"
+				"acp-kernel": "0.0.24"
 			},
 			"devDependencies": {
 				"@deepseek-ai/cordis": "4.0.1",
@@ -1567,9 +1567,9 @@
 			}
 		},
 		"node_modules/acp-kernel": {
-			"version": "0.0.23",
-			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.23.tgz",
-			"integrity": "sha512-bG28aYfBda8z34fsaoNc4QBix4gRtQDQznR6G4XBaz9z1xgxdmdYtazQQMBjxnfEL9yCrDb9CTpkl7IXWiuviA==",
+			"version": "0.0.24",
+			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.24.tgz",
+			"integrity": "sha512-vuNpkTjeTvNprqTRSlFCRuVpqoqdyHY00ejS+lRfdqQYfrOtA2LgfJNF3Aun7ibu2d+llaA6H5WYznpGkJNC/A==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"test": "node --import tsx --test tests/*.test.ts"
 	},
 	"dependencies": {
-		"acp-kernel": "0.0.23"
+		"acp-kernel": "0.0.24"
 	},
 	"peerDependencies": {
 		"@deepseek-ai/cordis": "^4.0.1",


### PR DESCRIPTION
## Changes

Bump `acp-kernel` from pinned `0.0.23` to `0.0.24`.

### Breaking change analysis

| Change | Location | Impact |
|---|---|---|
| `NudgeConfig.tier2GrowthMultiplier` (default 1.5) | types.ts | None — inherited via `defaultConfig` |
| `mergeRangesToThreshold` + effective filter | recommend.ts, compress.ts | None — we self-compute the range table |
| `decideNudge` arbitration rewrite | compress.ts | None — internal; we consume `NudgeDecision` output |
| Token scale-drop resets `lastShownByTier` | compress.ts | None — internal |
| Emergency tier-2/3 nudge text uses emergency voice | nudge-text.ts | None — we build our own nudge text |

All API types we use (`CompressionState`, `CompressionBlock`, `NudgeDecision`, `CompressionCore`, `createInitialState`, `defaultConfig`, `defaultCountTokens`) are **unchanged**.

### Verification

- `npm run typecheck` ✅
- `npm test` — 62/62 pass ✅
- `npm run build` — 52.18 KB ESM ✅