### PR TITLE
release v0.1.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ dist/
 
 # Worktrees (local development only, never push)
 worktrees/
+
+# Scratch / planning files (local only, never push)
+scratch-*
+docs/fix-issue-*-plan.md
+docs/video-script.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ Design decisions (see docs/dsh-porting-verification.md for the full evidence):
 2. **Seq is the ref** — no `<acp>` tags; the nudge's range table carries surface seqs.
 3. **No automatic summarization** — `compactIfNeeded` returns null; nudges are advisory, never imperative ("the choice and timing are yours").
 4. **Model-driven summaries** — the model writes the summary via `compress`; no second LLM summarization call.
-5. **`acp-kernel` pinned to an exact version** (e.g. `"acp-kernel": "0.0.23"`, NEVER `^`). It is inlined by tsup; a caret range breaks reproducibility.
+5. **`acp-kernel` pinned to an exact version** (e.g. `"acp-kernel": "0.0.24"`, NEVER `^`). It is inlined by tsup; a caret range breaks reproducibility.
 
 ## 3. Hard-won rules (from v0.1.1 long-session battle)
 
@@ -83,7 +83,7 @@ The PR title is enforced by CI (`.github/workflows/pr-lint.yml` → `scripts/che
 
 ## 4b. acp-kernel upgrade policy (the kernel WILL move on)
 
-`acp-kernel` is pinned **exactly** (e.g. `0.0.23`, never `^`) because tsup inlines it — a caret range makes the resolved version drift when the lockfile regenerates, breaking reproducible builds. But pinning is **not** freezing: upgrades are a controlled, manual process.
+`acp-kernel` is pinned **exactly** (e.g. `0.0.24`, never `^`) because tsup inlines it — a caret range makes the resolved version drift when the lockfile regenerates, breaking reproducible builds. But pinning is **not** freezing: upgrades are a controlled, manual process.
 
 **When to check:** on any feature work, or monthly — `npm view acp-kernel version`.
 

--- a/README.en.md
+++ b/README.en.md
@@ -3,7 +3,7 @@
 [English](./README.en.md) | [中文](./README.md)
 
 > **⚠️ Beta notice — not for production use**
-> This project (**v0.1.8**) is a work-in-progress beta. The [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) itself is also in **public beta**. **Do not use either in engineering / production environments** — expect breaking changes and rough edges.
+> This project (**v0.1.9**) is a work-in-progress beta. The [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) itself is also in **public beta**. **Do not use either in engineering / production environments** — expect breaking changes and rough edges.
 
 <p align="center">
 <strong>Built with gratitude on top of these projects</strong> — please give them a ⭐:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [中文](./README.md) | [English](./README.en.md)
 
 > **⚠️ 测试版声明——请勿用于生产环境**
-> 本项目（**v0.1.8**）仍处于开发中的测试版。[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 本身也处于**公开测试版**阶段。**请勿将两者用于工程化 / 生产环境**——预期会有破坏性变更与粗糙之处。
+> 本项目（**v0.1.9**）仍处于开发中的测试版。[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 本身也处于**公开测试版**阶段。**请勿将两者用于工程化 / 生产环境**——预期会有破坏性变更与粗糙之处。
 
 <p align="center">
 <strong>衷心感谢以下项目——请给它们一个 ⭐：</strong>

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 [English](./README.md) · [简体中文](../README.md) · [项目主页](https://github.com/Tyan66666/billion-context-dsh)
 
-> **⚠️ Beta** — this project (v0.1.8) and the [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) are both in **public beta**: do not use in engineering / production environments.
+> **⚠️ Beta** — this project (v0.1.9) and the [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) are both in **public beta**: do not use in engineering / production environments.
 
 Model-driven context management (Active Context Pruning / ACP) for the DeepSeek Harness, ported from [billion-context-pi](https://github.com/ranxianglei/billion-context-pi). The compression core ([acp-kernel](https://github.com/ranxianglei/acp-kernel)) is reused verbatim.
 
@@ -33,6 +33,7 @@ src/
 
 ## 📦 Releases
 
+- [v0.1.9](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.9) — (chore) bump acp-kernel 0.0.23 → 0.0.24 (inline-dependency upgrade); docs: update acp-kernel version reference in AGENTS.md; 62 tests pass (no regression)
 - [v0.1.8](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.8) — (fix) system prompt section cold-start retry: the ACP guidance section is now registered even when the `systemPrompt` service activates after the engine — matches the same retry pattern used by tools and commands; (fix) nudge context pressure now reads from `sessionProjections.contextPressure.projectedTokens` (matches the UI context-occupancy display; includes fixed overhead) instead of `tokenMeter.measure(session).surfaceTokens`; docs: INSTALL.md 2a notes that disabling compaction-basic is redundant on dsh 0.1.0-rc.6+; + 3 regression tests (62 tests)
 - [v0.1.7](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.7) — (fix) compress no longer fails with *seq not in the current surface* when the model reuses stale refs (old nudge tables / earlier compress results): shadowed edges are remapped to the still-live content of the requested span, a fully shadowed span is reported as *already compressed* with the covering block ids, block checkpoint nodes are never folded on a stale reference (distillation stays explicit), and invented/other-session seqs still fail with acp_status guidance; guidance updated in the system prompt, nudge range table and compress tool description, + 6 regression tests (60 tests)
 - [v0.1.6](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.6) — (feat) auto-detect the model context window from the LLM runtime (`agent.ctx.llm.resolveModelInfo`; explicit `modelContextLimit` wins, falls back to the default), (feat) engine nudge thresholds lowered to 0.70/0.85 (forced nudge before the host 80% compaction line; explicit values win), docs: clarify nudge trigger semantics — growth path has no percentage floor, + 3 regression tests (54 tests)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # billion-context-dsh
 
-> **⚠️ Beta notice** — this project (v0.1.8) and the [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) are both in **public beta**: do not use in engineering / production environments.
+> **⚠️ Beta notice** — this project (v0.1.9) and the [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) are both in **public beta**: do not use in engineering / production environments.
 
 **Model-driven context management (Active Context Pruning / ACP) for the DeepSeek Harness.** The model decides *when* and *what* to compress — not a hard limit. Ported from [billion-context-pi](https://github.com/ranxianglei/billion-context-pi) (by [ranxianglei](https://github.com/ranxianglei), MIT); the compression core [acp-kernel](https://github.com/ranxianglei/acp-kernel) is reused verbatim.
 
@@ -19,6 +19,6 @@
 ## 🔗 Quick links
 
 - **Repository**: [github.com/Tyan66666/billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh)
-- **npm**: [billion-context-dsh@0.1.8](https://www.npmjs.com/package/billion-context-dsh)
-- **Releases**: [v0.1.8](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.8) · [v0.1.7](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.7) · [v0.1.6](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.6) · [v0.1.5](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.5) · [v0.1.4](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.4) · [v0.1.3](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.3) · [v0.1.2](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.2) · [v0.1.1](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.1) · [v0.1.0](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.0)
+- **npm**: [billion-context-dsh@0.1.9](https://www.npmjs.com/package/billion-context-dsh)
+- **Releases**: [v0.1.9](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.9) · [v0.1.8](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.8) · [v0.1.7](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.7) · [v0.1.6](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.6) · [v0.1.5](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.5) · [v0.1.4](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.4) · [v0.1.3](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.3) · [v0.1.2](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.2) · [v0.1.1](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.1) · [v0.1.0](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.0)
 - **Upstream**: [billion-context-pi](https://github.com/ranxianglei/billion-context-pi) · [acp-kernel](https://github.com/ranxianglei/acp-kernel) · [opencode-acp](https://github.com/ranxianglei/opencode-acp) · [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.1.8",
 			"license": "MIT",
 			"dependencies": {
-				"acp-kernel": "0.0.23"
+				"acp-kernel": "0.0.24"
 			},
 			"devDependencies": {
 				"@deepseek-ai/cordis": "4.0.1",
@@ -1567,9 +1567,9 @@
 			}
 		},
 		"node_modules/acp-kernel": {
-			"version": "0.0.23",
-			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.23.tgz",
-			"integrity": "sha512-bG28aYfBda8z34fsaoNc4QBix4gRtQDQznR6G4XBaz9z1xgxdmdYtazQQMBjxnfEL9yCrDb9CTpkl7IXWiuviA==",
+			"version": "0.0.24",
+			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.24.tgz",
+			"integrity": "sha512-vuNpkTjeTvNprqTRSlFCRuVpqoqdyHY00ejS+lRfdqQYfrOtA2LgfJNF3Aun7ibu2d+llaA6H5WYznpGkJNC/A==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "billion-context-dsh",
-	"version": "0.1.8",
+	"version": "0.1.9",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-dsh",
-			"version": "0.1.8",
+			"version": "0.1.9",
 			"license": "MIT",
 			"dependencies": {
 				"acp-kernel": "0.0.24"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-dsh",
-	"version": "0.1.8",
+	"version": "0.1.9",
 	"description": "Active Context Pruning (ACP) for the DeepSeek Harness — model-driven context management as a CompactionEngine backend.",
 	"type": "module",
 	"main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"test": "node --import tsx --test tests/*.test.ts"
 	},
 	"dependencies": {
-		"acp-kernel": "0.0.23"
+		"acp-kernel": "0.0.24"
 	},
 	"peerDependencies": {
 		"@deepseek-ai/cordis": "^4.0.1",


### PR DESCRIPTION
## v0.1.9

**Changes since v0.1.8:**
- (chore) bump acp-kernel 0.0.23 → 0.0.24 (inline-dependency upgrade)
- (docs) update acp-kernel version reference in AGENTS.md
- (chore) add scratch/planning files to .gitignore

**Pre-flight:** ✅ typecheck · ✅ 62/62 tests · ✅ build

> **Note:** Agent must NOT merge. Human-only per CONTRIBUTING.md.