### PR TITLE
(feat) align nudge and system-prompt copy with acp-kernel/billion-context-pi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ worktrees/
 scratch-*
 docs/fix-issue-*-plan.md
 docs/video-script.md
+.npm-cache/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ src/
 ├── state.ts        # M2: per-session kernel state
 ├── region.ts       # M5: durable region transaction + log-rebuilt ledger + surface range solving
 ├── tools.ts        # M3: compress / decompress / search_context / acp_status
-├── nudge.ts        # M4: advisory nudge (surface-computed range table)
+├── nudge.ts        # M4: kernel renderNudgeText (default) + seq-range-table adaptation; template path on prompts override
 ├── system-prompt.ts# M4: one-time ACP guidance section
 ├── prompts.ts      # M4: configurable prompt templates + render/validate (config.prompts)
 ├── config.ts       # kernel config assembly (thresholds + coreOverrides)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Design decisions (see docs/dsh-porting-verification.md for the full evidence):
 
 1. **Durable surface model** — DSH has NO in-memory message rewrite hook (`llm/stream` is read-only, `deriveMessages` is a pure projection). All compression is a durable `surfaceOp: { op: 'replace' }`; originals stay in the append-only log (decompress/search rebuild from the log).
 2. **Seq is the ref** — no `<acp>` tags; the nudge's range table carries surface seqs.
-3. **No automatic summarization** — `compactIfNeeded` returns null; nudges are advisory, never imperative ("the choice and timing are yours").
+3. **No automatic summarization** — `compactIfNeeded` returns null; nudges are advisory, never imperative (default copy aligned with kernel/pi: efficiency note, not "suggestion, not a requirement"; the emergency tier alone says "compress now").
 4. **Model-driven summaries** — the model writes the summary via `compress`; no second LLM summarization call.
 5. **`acp-kernel` pinned to an exact version** (e.g. `"acp-kernel": "0.0.24"`, NEVER `^`). It is inlined by tsup; a caret range breaks reproducibility.
 

--- a/README.en.md
+++ b/README.en.md
@@ -76,19 +76,19 @@ That's it. Then add a composition row where a compaction backend is expected —
         modelContextLimit: 128000   # optional; omit to auto-detect the model's real window (fallback 128000)
 ```
 
-**(Optional) Custom prompt copy — `config.prompts`.** Every model-visible prompt (normal/emergency nudge opener, tier line, range table, the ACP system-prompt section, the four tool descriptions) ships with built-in copy that you can override per slot through the composition row's `config`. Templates support named placeholders (e.g. `{pct}` for nudges, `{surface}` for the range table) and are **validated at construction**: a misspelled placeholder fails engine startup (fail-fast) instead of leaking a literal `{pct}` into the model context:
+**(Optional) Custom prompt copy — `config.prompts`.** Every model-visible prompt (normal/emergency nudge opener, context breakdown, growth line, batch tip, tier line, range table, the ACP system-prompt section, the four tool descriptions) ships with built-in copy (aligned with acp-kernel / billion-context-pi's nudge style: efficiency note + context breakdown + compression rules) that you can override per slot through the composition row's `config`. Templates support named placeholders (e.g. `{pct}` and `{philosophy}` for nudges, `{surface}` for the range table) and are **validated at construction**: a misspelled placeholder fails engine startup (fail-fast) instead of leaking a literal `{pct}` into the model context:
 
 ```yaml
       config:
         modelContextLimit: 128000
         prompts:
           nudge:
-            normal: 'Context usage is at {pct}%. This is a suggestion, not a requirement — you decide.'  # custom nudge opener
+            normal: 'Context usage is at {pct}%. This is an efficiency nudge to compress early and keep context lean.'  # custom nudge opener
           tools:
             acpStatus: 'Report the ACP block ledger: compressed blocks, reclaimed tokens, and current context pressure.'  # custom tool description
 ```
 
-See [docs/configurable-prompts-design.md](docs/configurable-prompts-design.md) for the full slot list, per-slot placeholders, and the empty-string/`null` semantics. Deployments that omit `prompts` behave exactly as before (default copy byte-identical).
+See [docs/configurable-prompts-design.md](docs/configurable-prompts-design.md) for the full slot list, per-slot placeholders, and the empty-string/`null` semantics. Deployments that omit `prompts` use the built-in default copy (aligned with kernel/pi; see design doc v5).
 
 **Per-mode — an agent preset's `compaction` realm.** First *disable (or delete) the realm's existing `dsh-compaction-basic` row*, then mount this engine — two backends cannot coexist in the same realm:
 
@@ -114,14 +114,14 @@ DSH derives every model request from its append-only session log (the *surface*)
 |---|---|
 | `compress` tool shadows a range | durable `surfaceOp: { op: 'replace' }` — the model-written summary becomes a checkpoint node; the originals stay in the log |
 | refs (`m00001` tags) | surface seqs, carried by the nudge's compressible-range table |
-| nudge ("consider compressing") | injected at `agent/pre-step` by the kernel's pressure decision — a short advisory, never an order |
+| nudge ("efficiency note — compress early and keep context lean") | injected at `agent/pre-step` by the kernel's pressure decision — efficiency note + context breakdown + compression rules, tone aligned with kernel/pi; never an order |
 | `decompress` | read-only recovery of shadowed originals from the log |
 | `search_context` | scores block summaries + originals rebuilt from the log |
 | `acp_status` | block ledger + context pressure |
 | block state | in-memory kernel state + **log-rebuilt ledger** (no sidecar files) |
 | tiered distillation (T2/T3) | re-compressing a block's summary node distills that block (tier 2); distilling a tier-2 block yields tier 3. Tier + kernel block ids are persisted to the log, so kernel state rehydrates from the log after a restart and stays distillable |
 
-The load-bearing compression guidance (tools, philosophy, summary rules) is registered as a one-time system-prompt section, so nudges stay short. There is deliberately **no automatic summarization**: automatic policy only nudges the model (`compactIfNeeded` returns null).
+The load-bearing compression guidance (tools, philosophy, summary rules, tier rules) is registered as a one-time system-prompt section; each nudge carries a condensed version (efficiency note + philosophy + context breakdown + HOW_TO_COMPRESS_RULES + range table + batch tip). There is deliberately **no automatic summarization**: automatic policy only nudges the model (`compactIfNeeded` returns null).
 
 ## Video
 

--- a/README.en.md
+++ b/README.en.md
@@ -83,7 +83,7 @@ That's it. Then add a composition row where a compaction backend is expected —
         modelContextLimit: 128000
         prompts:
           nudge:
-            normal: 'Context usage is at {pct}%. This is an efficiency nudge to compress early and keep context lean.'  # custom nudge opener
+            normal: 'This is an efficiency nudge to compress early and keep context lean.'  # custom nudge opener
           tools:
             acpStatus: 'Report the ACP block ledger: compressed blocks, reclaimed tokens, and current context pressure.'  # custom tool description
 ```
@@ -190,6 +190,7 @@ src/
 ├── nudge.ts        # M4: kernel pressure decision → injected advisory nudge
 ├── system-prompt.ts# M4: one-time ACP guidance section (keeps nudges short)
 ├── config.ts       # kernel config assembly (thresholds + coreOverrides)
+├── window.ts       # auto context-window detection (LLM runtime probe, fallback 128000)
 └── commands.ts     # M4: /acp slash command
 ```
 

--- a/README.en.md
+++ b/README.en.md
@@ -76,7 +76,7 @@ That's it. Then add a composition row where a compaction backend is expected —
         modelContextLimit: 128000   # optional; omit to auto-detect the model's real window (fallback 128000)
 ```
 
-**(Optional) Custom prompt copy — `config.prompts`.** Every model-visible prompt (normal/emergency nudge opener, context breakdown, growth line, batch tip, tier line, range table, the ACP system-prompt section, the four tool descriptions) ships with built-in copy (aligned with acp-kernel / billion-context-pi's nudge style: efficiency note + context breakdown + compression rules) that you can override per slot through the composition row's `config`. Templates support named placeholders (e.g. `{pct}` and `{philosophy}` for nudges, `{surface}` for the range table) and are **validated at construction**: a misspelled placeholder fails engine startup (fail-fast) instead of leaking a literal `{pct}` into the model context:
+**(Optional) Custom prompt copy — `config.prompts`.** Every model-visible prompt (normal/emergency nudge opener, context breakdown, growth line, batch tip, tier line, range table, the ACP system-prompt section, the four tool descriptions) defaults to **acp-kernel's own `renderNudgeText`** — the efficiency note, context breakdown, compression rules, and batch tip all come from the kernel verbatim; only the range table is swapped for the surface-seq version (the kernel uses mNNNNN refs, and DSH has no `<acp>` tags). Overriding any nudge slot switches to template rendering. Templates support named placeholders (e.g. `{pct}` and `{philosophy}` for nudges, `{surface}` for the range table) and are **validated at construction**: a misspelled placeholder fails engine startup (fail-fast) instead of leaking a literal `{pct}` into the model context:
 
 ```yaml
       config:
@@ -88,7 +88,7 @@ That's it. Then add a composition row where a compaction backend is expected —
             acpStatus: 'Report the ACP block ledger: compressed blocks, reclaimed tokens, and current context pressure.'  # custom tool description
 ```
 
-See [docs/configurable-prompts-design.md](docs/configurable-prompts-design.md) for the full slot list, per-slot placeholders, and the empty-string/`null` semantics. Deployments that omit `prompts` use the built-in default copy (aligned with kernel/pi; see design doc v5).
+See [docs/configurable-prompts-design.md](docs/configurable-prompts-design.md) for the full slot list, per-slot placeholders, and the empty-string/`null` semantics. Deployments that omit `prompts` use the kernel rendering directly (aligned with kernel/pi; see design doc v6).
 
 **Per-mode — an agent preset's `compaction` realm.** First *disable (or delete) the realm's existing `dsh-compaction-basic` row*, then mount this engine — two backends cannot coexist in the same realm:
 

--- a/README.md
+++ b/README.md
@@ -78,19 +78,19 @@ npm install billion-context-dsh
         modelContextLimit: 128000   # 可选；省略时自动探测模型真实窗口（回退 128000）
 ```
 
-**（可选）自定义提示词文案 —— `config.prompts`。** 所有模型可见的提示词（普通/紧急 nudge 首句、tier 蒸馏行、范围表、ACP system prompt 段、四个工具描述）默认是内置文案，可通过组合行的 `config` 按槽位覆盖。模板支持命名占位符（如 nudge 的 `{pct}`、范围表的 `{surface}`），**构造期校验**：占位符拼写错误会在引擎启动时抛错（fail-fast），而不是把字面 `{pct}` 漏进模型上下文：
+**（可选）自定义提示词文案 —— `config.prompts`。** 所有模型可见的提示词（普通/紧急 nudge 首句、上下文分解、增长行、批量提示、tier 蒸馏行、范围表、ACP system prompt 段、四个工具描述）默认是内置文案（已对齐 acp-kernel / billion-context-pi 的 nudge 风格：效率提示 + 上下文分解 + 压缩规则），可通过组合行的 `config` 按槽位覆盖。模板支持命名占位符（如 nudge 的 `{pct}`、`{philosophy}`、范围表的 `{surface}`），**构造期校验**：占位符拼写错误会在引擎启动时抛错（fail-fast），而不是把字面 `{pct}` 漏进模型上下文：
 
 ```yaml
       config:
         modelContextLimit: 128000
         prompts:
           nudge:
-            normal: '上下文使用率 {pct}%。这是建议而非命令——由你决定是否压缩。'  # 中文 nudge 首句
+            normal: '上下文使用率 {pct}%。这是效率提示——请尽早压缩保持上下文精简。'  # 中文 nudge 首句
           tools:
             acpStatus: '报告 ACP 块账本：压缩块数、回收 token、当前上下文压力。'  # 自定义工具描述
 ```
 
-可配置槽位清单、每槽可用占位符、空串/`null` 语义见 [docs/configurable-prompts-design.md](docs/configurable-prompts-design.md)。未配置 `prompts` 的部署行为与以往完全一致（默认文案逐字节不变）。
+可配置槽位清单、每槽可用占位符、空串/`null` 语义见 [docs/configurable-prompts-design.md](docs/configurable-prompts-design.md)。未配置 `prompts` 的部署使用内置默认文案（对齐 kernel/pi，见设计文档 v5）。
 
 **单模式生效（agent preset 的 `compaction` realm）**。先在该 realm 内*禁用（或删除）原有的 `dsh-compaction-basic` 行*，再插入本引擎——同一 realm 内两个后端不能并存：
 
@@ -116,14 +116,14 @@ DSH 的每个模型请求都派生自其 append-only 会话日志（*surface*）
 |---|---|
 | `compress` 工具遮蔽一段范围 | 持久化 `surfaceOp: { op: 'replace' }`——模型书写的摘要成为 checkpoint 节点；原文保留在日志中 |
 | refs（`m00001` 标签） | surface seq，由 nudge 的可压缩范围表携带 |
-| nudge（"考虑压缩一下"） | 由内核的压力决策在 `agent/pre-step` 注入——简短建议，绝非命令 |
+| nudge（"效率提示——尽早压缩保持精简"） | 由内核的压力决策在 `agent/pre-step` 注入——效率通知 + 上下文分解 + 压缩规则，语气对齐 kernel/pi；绝非命令 |
 | `decompress` | 从日志只读恢复被遮蔽的原文 |
 | `search_context` | 对从日志重建的块摘要与原文打分 |
 | `acp_status` | 块账本与上下文压力 |
 | 块状态 | 内存内核状态 + **日志重建账本**（无旁车文件） |
 | 分层蒸馏（T2/T3） | 再次压缩某块的摘要节点 = 蒸馏该块（tier 2），蒸馏 tier-2 块得 tier 3；tier 与内核块 id 持久化进日志，重启后内核状态从日志再水合、可继续蒸馏 |
 
-承载性的压缩指引（工具、哲学、摘要规则）注册为一次性系统提示段，因此 nudge 保持简短。刻意**不做自动摘要**：自动策略只 nudge 模型（`compactIfNeeded` 返回 null）。
+承载性的压缩指引（工具、哲学、摘要规则、tier 蒸馏/浓缩规则）注册为一次性系统提示段；每条 nudge 携带精简版（效率提示 + 哲学 + 上下文分解 + 压缩规则 + 范围表 + 批量提示）。刻意**不做自动摘要**：自动策略只 nudge 模型（`compactIfNeeded` 返回 null）。
 
 ## 视频讲解
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ npm install billion-context-dsh
         modelContextLimit: 128000   # 可选；省略时自动探测模型真实窗口（回退 128000）
 ```
 
-**（可选）自定义提示词文案 —— `config.prompts`。** 所有模型可见的提示词（普通/紧急 nudge 首句、上下文分解、增长行、批量提示、tier 蒸馏行、范围表、ACP system prompt 段、四个工具描述）默认是内置文案（已对齐 acp-kernel / billion-context-pi 的 nudge 风格：效率提示 + 上下文分解 + 压缩规则），可通过组合行的 `config` 按槽位覆盖。模板支持命名占位符（如 nudge 的 `{pct}`、`{philosophy}`、范围表的 `{surface}`），**构造期校验**：占位符拼写错误会在引擎启动时抛错（fail-fast），而不是把字面 `{pct}` 漏进模型上下文：
+**（可选）自定义提示词文案 —— `config.prompts`。** 所有模型可见的提示词（普通/紧急 nudge 首句、上下文分解、增长行、批量提示、tier 蒸馏行、范围表、ACP system prompt 段、四个工具描述）默认**直接复用 acp-kernel 的 `renderNudgeText`**——效率提示、上下文分解、压缩规则、批量提示全部来自 kernel 原文，仅范围表换成 surface-seq 版（kernel 用 mNNNNN 引用，我们架构没有 `<acp>` 标签）。覆盖任一 nudge 槽位后自动切换到模板渲染。模板支持命名占位符（如 nudge 的 `{pct}`、`{philosophy}`、范围表的 `{surface}`），**构造期校验**：占位符拼写错误会在引擎启动时抛错（fail-fast），而不是把字面 `{pct}` 漏进模型上下文：
 
 ```yaml
       config:
@@ -90,7 +90,7 @@ npm install billion-context-dsh
             acpStatus: '报告 ACP 块账本：压缩块数、回收 token、当前上下文压力。'  # 自定义工具描述
 ```
 
-可配置槽位清单、每槽可用占位符、空串/`null` 语义见 [docs/configurable-prompts-design.md](docs/configurable-prompts-design.md)。未配置 `prompts` 的部署使用内置默认文案（对齐 kernel/pi，见设计文档 v5）。
+可配置槽位清单、每槽可用占位符、空串/`null` 语义见 [docs/configurable-prompts-design.md](docs/configurable-prompts-design.md)。未配置 `prompts` 的部署直接使用 kernel 渲染（对齐 kernel/pi，见设计文档 v6）。
 
 **单模式生效（agent preset 的 `compaction` realm）**。先在该 realm 内*禁用（或删除）原有的 `dsh-compaction-basic` 行*，再插入本引擎——同一 realm 内两个后端不能并存：
 

--- a/docs/configurable-prompts-design.md
+++ b/docs/configurable-prompts-design.md
@@ -1,5 +1,11 @@
-# 可配置提示词设计(Configurable Prompts Design)— v5
+# 可配置提示词设计(Configurable Prompts Design)— v6
 
+> **修订记录(v6,默认 nudge 渲染改走 kernel `renderNudgeText`;compress 工具参数包裹容错):**
+> - **R1**:默认(无 `prompts.nudge` 覆盖)`buildNudgeText` 直接调用 kernel `renderNudgeText(nudge)`——EFFICIENCY_NOTE/EMERGENCY_HEADER、breakdown、HOW_TO_COMPRESS_RULES、TIER2/3 规则、`💡` tip **全部来自 acp-kernel 原文**,不再手抄模板。仅把 ref-ID 导向的段替换为 surface-seq 版本:`rangesStr`(mNNNNN)→ 我们的范围表;紧急档 JSON example(startId/endId)→ seq 示例;tier 触发块(bN block ids)→ 我们的 tier 行。零范围时保留 kernel 的 "[No specific ranges detected]" 提示。
+> - **R2**:**双路径分派**——`prompts.nudge !== DEFAULT_RESOLVED.nudge`(宿主覆盖了任何 nudge 槽位)→ 走模板渲染路径(`renderNudgeFromTemplates`,v5 装配原样保留,config.prompts 定制优先);否则走 kernel 路径。默认引用(未覆盖)与模板路径按引用相等判断。
+> - **R3**:kernel 路径下紧急档**无 `💡 tip`**(kernel 紧急分支没有批量提示行)——这是与 kernel 对齐的行为变化,测试 #3 断言同步更新。
+> - **R4**:**compress 工具参数包裹容错**——部分模型把参数写成 `{ "arguments": "{\"content\": [...]}" }`(双重嵌套)或 `{ "arguments": { "content": [...] } }`;旧 DSH 校验器报 `invalid arguments: "arguments" must be an object` 导致模型无限重试。修复:schema 增加可选 `arguments`(type: `json`)节点 + `content` 去掉 `required: true`(required 会在解包前拒绝包裹形态),`handleCompress` 用 `unwrapCompressArgs` 解包;两种形态都不带 content 时报清晰错误。
+>
 > **修订记录(v5,对齐 kernel/billion-context-pi 的 nudge 文案与装配):**
 > - **K1**:默认 nudge 文案对齐 kernel——普通档首句从"suggestion, not a requirement"改为"efficiency nudge to compress early and keep context lean";紧急档从"Consider…the choice is yours"改为"⚠️ Context limit reached — compress now";两档均在模板中嵌入 `{philosophy}`(kernel `COMPRESS_PHILOSOPHY`)。
 > - **K2**:`NudgePrompts` 新增 3 个槽位——`breakdown`(上下文分解,占位符 `{system} {tool} {summaries} {code} {text}`)、`growth`(增长行,`{growth}`)、`tip`(批量压缩提示,无占位符);默认值逐字对齐 kernel `nudge-text.ts` 的 `formatBreakdown` / `formatRanges` 尾部 `💡` 行。
@@ -199,10 +205,26 @@ export function renderSystemPrompt(prompts: ResolvedPrompts): string { … }
 - **组级 null 防御(W3)**:YAML 宿主可能写 `prompts: { nudge: null }`(键级 null 在 TS 下合法,组级 null 过不了类型但 YAML 无类型检查);`resolvePrompts` 对组级 null 视为**整组用默认**——逐键比较前先做组级归一化;
 - 类型层面 `PromptInput = string | null`,`ResolvedPrompts` 全是 `string`——null 只存在于输入侧,解析后被归一化,消费方永远看到 string。
 
-**空串删除的精确装配语义(I5/N1 定案,叠加 K3 对齐 kernel 后的装配顺序)——以 nudge 为例:**
+**双路径装配(R1/R2 定案,v6)——默认走 kernel 渲染,覆盖走模板:**
 
 ```
-nudge 装配(v5,对齐 kernel renderNudgeText 的顺序):
+buildNudgeText(nudge, emergency, session, prompts):
+  if (prompts.nudge !== DEFAULT_RESOLVED.nudge):        // R2:宿主覆盖了 nudge 槽位
+    return renderNudgeFromTemplates(...)                 // 模板路径(v5 装配,见下)
+  // 默认:kernel renderNudgeText + seq 段适配(R1)
+  rendered = renderNudgeText(nudge)                      // EFFICIENCY_NOTE/EMERGENCY_HEADER、
+                                                         // breakdown、HOW_TO_COMPRESS_RULES、
+                                                         // TIER2/3 规则、💡 tip 全部来自 kernel 原文
+  return adaptKernelNudgeToSeq(rendered.text, ...):
+    if (tier 2/3 && tierTargetBlocks 非空)  replaceTierTrigger(...)   // bN 块 id 段 → 我们的 tier 行(seqs)
+    else if (text 含 '"startId"')           replaceEmergencyExample(...) // startId/endId 示例 → seq 示例
+    if (rangeTable(session, prompts) !== '') replaceRangesStr(...)      // mNNNNN 范围表 → surface-seq 表
+    // 零范围:保留 kernel 的 "[No specific ranges detected]" 提示(比空表好)
+```
+
+模板路径(仅覆盖时)装配顺序(v5 原样,config.prompts 定制优先):
+
+```
   parts = [frame]                       // frame = normal/emergency 模板渲染({pct} + {philosophy} 内嵌)
   if (breakdown 渲染非空)  push('', breakdown)   // P8,来自 nudge.contextBreakdown
   if (growth 渲染非空)     push(growth)          // P9,仅 contextBreakdown.growth > 0 时渲染
@@ -217,16 +239,15 @@ nudge 装配(v5,对齐 kernel renderNudgeText 的顺序):
   return parts.join('\n')
 ```
 
-字节对照表(v5;K3 后装配顺序与 v4 不同,tier 分支不再渲染范围表):
+字节对照表(v6;R3 后默认紧急档**无 `💡 tip`**——kernel 紧急分支本来就没有批量提示行):
 
 | 情形 | 完整字节 |
 |---|---|
-| 默认有范围(非 tier) | `frame` `\n\n` `breakdown` `\n` `growth` `\n\n` `guidance` `\n\n` `Surface: …` `\n\n` `tip`(breakdown/growth/guidance 各带分隔;表前空行由范围表内部前导元素提供) |
-| 无 breakdown/growth | `frame` `\n\n` `guidance` `\n\n` `Surface: …` `\n\n` `tip` |
-| tier nudge | `frame` `\n\n` `breakdown` … `\n\n` `guidance` `\n` `tierLine` `\n\n` `TIER2_DISTILL_RULES…` `\n\n` `tip`(**无范围表**,K3) |
-| 零范围(非 tier) | `frame` `\n\n` `guidance` `\n` `\n` `tip`(范围表返回 `''` 仍被 push,尾部换行是字节的一部分) |
-| `guidance: ''`(有范围) | `frame` `\n\n` `breakdown`… `\n\n` `Surface: …` `\n\n` `tip`(干净删除 guidance;表前空行仍由范围表前导元素提供) |
-| `normal: ''` | 输出以 `\n\n` 开头(实测,S4;允许,文档如此定义) |
+| 默认有范围(非 tier) | kernel 渲染,`rangesStr` 段替换为 `\n` + 我们的范围表;尾部 `💡 tip` 保留 |
+| 默认紧急档 | kernel 渲染,JSON example 段替换为 seq 示例 + `rangesStr` 段替换为范围表;**无 tip**(R3,kernel 对齐) |
+| 默认 tier | kernel 渲染,`[TIER n TRIGGER]` 段替换为我们的 tier 行;TIER2/3 规则保留 |
+| 默认零范围 | kernel 渲染,保留 "[No specific ranges detected]" 提示(R1,不替换为空) |
+| 覆盖路径 | 模板装配(v5 字节表原样) |
 
 **三个最容易写错的细节(N1/W1):**
 1. 范围表**不在 parts 层再加 `''` 分隔**——表前空行完全由范围表内部前导元素提供(§5.2),再加就是双分隔;
@@ -240,6 +261,8 @@ nudge 装配(v5,对齐 kernel renderNudgeText 的顺序):
 > **实现时与 main v0.1.8 对齐**:本设计定稿于 main v0.1.7 时代,实现 rebase 到 v0.1.8 后,默认文案已同步 main 的新增内容——范围表 footer 追加 stale-seq 提示行(提交 `ea1de6a`)、compress 工具描述追加 stale-remap 句(同提交)、system prompt 的 compress/acp_status 描述行更新(同提交)。下方示例即实现 `DEFAULT_PROMPTS` 的逐字内容。
 
 ### 5.1 nudge
+
+> **R1 注**:默认(无覆盖)渲染**不经过这些模板**——`buildNudgeText` 直接调用 kernel `renderNudgeText`,帧/breakdown/规则/tip 全部来自 kernel 原文。下方 DEFAULT_PROMPTS.nudge 的模板值仅用于**宿主覆盖时**的模板路径(`renderNudgeFromTemplates`),作为"未覆盖槽位"的基线;它们的文本与 kernel 逐字对齐,保证覆盖路径与 kernel 路径输出一致。
 
 ```ts
 nudge: {
@@ -326,8 +349,8 @@ tools: {
 |---|---|
 | `src/prompts.ts`(新) | 类型 + `DEFAULT_PROMPTS` + `DEFAULT_RESOLVED` + `resolvePrompts` + `renderTemplate` + `renderSystemPrompt` |
 | `src/index.ts` | 新增实例字段 `readonly prompts: ResolvedPrompts`(赋值先于 env 构建,S5);`AcpConfig` 加 `readonly prompts?: AcpPrompts`;构造器 `this.prompts = resolvePrompts(config.prompts)`(**fail-fast**);env 带 `prompts: this.prompts`;system prompt section 用 `renderSystemPrompt(this.prompts)`;**顺带修复(I-建议4)**:systemPrompt.section 注册补 `internal/service` 冷启动重试(与同文件 tools/commands 的 registerTools 模式一致,现状 `ctx.get('systemPrompt')` 缺席时 ACP 段落会永久丢失) |
-| `src/nudge.ts` | `NudgeEnvironment` 加 `readonly prompts?: ResolvedPrompts`;**B1 关键行**:`buildNudge` 内 `nudge.ts:100` 的调用改为 `buildNudgeText(nudge, emergency, session, env.prompts)`——这是配置进入 nudge 的**唯一转发点**,漏掉 = 配置被接受但静默失效;`buildNudgeText(nudge, emergency, session, prompts = DEFAULT_RESOLVED)`(可选末参);`rangeTable(session, prompts = DEFAULT_RESOLVED)`;拼装改用模板渲染(**K3 装配顺序**:frame → breakdown → growth → guidance → tier(+tier 规则)/范围表 → tip) |
-| `src/tools.ts` | `ToolEnvironment` 加 `readonly prompts?: ResolvedPrompts`;`makeTools` 里四个 description 从 `env.prompts.tools.*` 取,缺省 `DEFAULT_RESOLVED` |
+| `src/nudge.ts` | `NudgeEnvironment` 加 `readonly prompts?: ResolvedPrompts`;**B1 关键行**:`buildNudge` 内 `nudge.ts:100` 的调用改为 `buildNudgeText(nudge, emergency, session, env.prompts)`——这是配置进入 nudge 的**唯一转发点**,漏掉 = 配置被接受但静默失效;`buildNudgeText(nudge, emergency, session, prompts = DEFAULT_RESOLVED)`(可选末参);`rangeTable(session, prompts = DEFAULT_RESOLVED)`;**R1/R2 双路径**:默认引用 → kernel `renderNudgeText` + `adaptKernelNudgeToSeq`(replaceRangesStr / replaceTierTrigger / replaceEmergencyExample);覆盖 → `renderNudgeFromTemplates`(模板装配) |
+| `src/tools.ts` | `ToolEnvironment` 加 `readonly prompts?: ResolvedPrompts`;`makeTools` 里四个 description 从 `env.prompts.tools.*` 取,缺省 `DEFAULT_RESOLVED`;**R4 容错**:compress schema 增加可选 `arguments`(type: `json`)节点、`content` 去掉 `required: true`;`handleCompress` 开头用 `unwrapCompressArgs` 解包 `{ arguments: "..." }` / `{ arguments: {...} }` 两种包裹形态,两种形态都不带 content 时报清晰错误 |
 | `src/system-prompt.ts` | `ACP_SYSTEM_PROMPT` 改为"默认模板渲染结果"导出(名称与语义不变);模板/渲染逻辑留在 `prompts.ts` |
 | `src/prompts.ts` | **K2**:`NudgePrompts` 新增 `breakdown` / `growth` / `tip` 槽位与默认模板;**K1**:normal/emergency 默认模板对齐 kernel(内嵌 `{philosophy}`);`guidance` 默认 = `HOW_TO_COMPRESS_RULES`;**K4**:systemPromptTemplate 新增 `{howToCompressRules}` / `{tier2DistillRules}` / `{tier3CondenseRules}` 占位符 + WHEN TO/WHEN NOT 段落;**K5**:`renderSystemPrompt` 注入 4 个 kernel 变量 |
 | `AGENTS.md` | 模块图加 `prompts.ts`(M4) |
@@ -341,9 +364,14 @@ tools: {
 - `rangeTable(session)` 不变(第二参可选);
 - `ACP_SYSTEM_PROMPT` / `ACP_SYSTEM_PROMPT_ORDER` 导出不变(`index.ts` 原样 re-export);
 - `AcpConfig` 现有字段全部不动,只新增 `prompts`;
-- 未配置 `prompts` 的部署:行为与 v5 的默认模板渲染一致(默认文案已对齐 kernel,见 K1–K4;这是**有意的**默认文案变更,不是兼容性破坏——`prompts` 槽位结构向后兼容,v4 部署写的 `nudge.normal` 覆盖仍然有效)。
+- 未配置 `prompts` 的部署:行为与 v5 的默认模板渲染一致(默认文案已对齐 kernel,见 K1–K4;这是**有意的**默认文案变更,不是兼容性破坏——`prompts` 槽位结构向后兼容,v4 部署写的 `nudge.normal` 覆盖仍然有效);
+- **R1/R2**:默认渲染从"模板装配"改为"kernel `renderNudgeText` + seq 段适配"——输出内容与 v5 默认模板渲染等价(EFFICIENCY_NOTE/breakdown/规则/tip 同源),但来源变为 kernel 原文;宿主覆盖任何 nudge 槽位时自动回退模板路径,覆盖语义不变;
+- **R3**:默认紧急档不再有 `💡 tip`(kernel 紧急分支没有批量提示行)——与 kernel 对齐的预期变化;
+- **R4**:compress 参数 schema 增加可选 `arguments`、`content` 不再 required——`{ content: [...] }` 与 `{ arguments: "..." }` 均接受,后者由 handleCompress 解包;旧的"包裹形态被拒"行为移除。
 
-## 8. 测试计划(v5:77 条回归全绿;§4/§5 快照按新默认文案重写)
+## 8. 测试计划(v6:80 条回归全绿;新增 kernel 路径 + 容错回归)
+
+> **v6 实现落地**:`tests/prompts.test.ts` #2 之后新增 #2b(kernel 路径验证——默认 nudge 含 EFFICIENCY_NOTE 帧、kernel HOW_TO_COMPRESS_RULES、💡 tip,ref 范围表被 surface-seq 表替换、无 "oldest first"、无 "Context usage is at");#3 紧急档断言改为"seq 示例替换 startId + 无 💡 tip(R3)";#11 tier fixture 补齐 kernel 需要的 block 字段(`effectiveMessageIds` 等);`tests/tools.test.ts` 新增 2 条容错回归(包裹字符串形态解包压缩成功、无 content 报清晰错误)。
 
 > **v5 实现落地**:`tests/prompts.test.ts` 的 #1/#2/#3/#10/#13 快照按新默认文案重写——#1 由整串字节对比改为"关键段落存在 + 旧语气缺席"(system prompt 变长且含 kernel 规则,整串快照维护成本高);#2/#3 改为断言 efficiency-note 首句、philosophy 内嵌、HOW_TO_COMPRESS_RULES 存在、💡 tip 结尾、旧文案缺席;#10 空串删除用例同时置空 breakdown/growth/tip 以验证干净装配;新增 breakdown/growth 槽位渲染断言(中文覆盖冒烟 #13 同步扩展)。
 

--- a/docs/configurable-prompts-design.md
+++ b/docs/configurable-prompts-design.md
@@ -1,5 +1,12 @@
-# 可配置提示词设计(Configurable Prompts Design)— v4
+# 可配置提示词设计(Configurable Prompts Design)— v5
 
+> **修订记录(v5,对齐 kernel/billion-context-pi 的 nudge 文案与装配):**
+> - **K1**:默认 nudge 文案对齐 kernel——普通档首句从"suggestion, not a requirement"改为"efficiency nudge to compress early and keep context lean";紧急档从"Consider…the choice is yours"改为"⚠️ Context limit reached — compress now";两档均在模板中嵌入 `{philosophy}`(kernel `COMPRESS_PHILOSOPHY`)。
+> - **K2**:`NudgePrompts` 新增 3 个槽位——`breakdown`(上下文分解,占位符 `{system} {tool} {summaries} {code} {text}`)、`growth`(增长行,`{growth}`)、`tip`(批量压缩提示,无占位符);默认值逐字对齐 kernel `nudge-text.ts` 的 `formatBreakdown` / `formatRanges` 尾部 `💡` 行。
+> - **K3**:nudge 装配顺序对齐 kernel `renderNudgeText`——`frame(内嵌 philosophy)` → `breakdown` → `growth` → `guidance`(默认 = kernel `HOW_TO_COMPRESS_RULES`) → `tier` 行(+ kernel `TIER2_DISTILL_RULES`/`TIER3_CONDENSE_RULES`) → 范围表(仅非 tier nudge) → `tip`。**tier nudge 不再渲染范围表**(tier 目标块由 tier 行 + 蒸馏规则承载,与 kernel 一致)。
+> - **K4**:system prompt 模板新增占位符 `{howToCompressRules}` / `{tier2DistillRules}` / `{tier3CondenseRules}`(分别注入 kernel `HOW_TO_COMPRESS_RULES` / `TIER2_DISTILL_RULES` / `TIER3_CONDENSE_RULES`),并新增 `WHEN TO COMPRESS` / `WHEN NOT TO COMPRESS` 场景清单(对齐 pi 的 `ACP_SYSTEM_PROMPT`);首段去掉 "Nothing forces you" 语气,改为效率通知框架。
+> - **K5**:`renderSystemPrompt` 的注入变量从 `{philosophy}` 单占位符扩展为 4 个;`buildNudgeText` 的 `{philosophy}` 由调用方渲染(normal/emergency 模板内嵌)。
+>
 > **修订记录(v4,终审后精度修正;第三轮评审实测结论:通过,可进入实现):**
 > - **W1**:§4 tier 行补"渲染非空"守卫,`tier: ''` = 删除该行,与 §4 值语义统一(默认模板恒渲染非空,对默认字节零影响);
 > - **W2**:§3.3 校验范围明确为"用户覆盖的模板",与 §6 `DEFAULT_RESOLVED` 零校验重跑一致;
@@ -37,7 +44,7 @@ billion-context-dsh 目前所有"模型可见"的提示词文本都是硬编码�
 
 目标:**通过宿主 composition 的 `config.prompts` 字段,按阶段覆盖这些提示词**,同时保证:
 
-1. **默认输出逐字节不变**——现有测试断言了精确子串,默认渲染必须与当前完全一致;
+1. **默认输出逐字节不变**——v4 的模板化迁移不改文案(现有测试断言了精确子串,默认渲染必须与迁移前完全一致);**v5 例外**:在模板化之上**故意**把默认 nudge 文案与 system prompt 对齐 kernel/billion-context-pi(K1–K4),该轮默认文案的字节以本 PR 的新快照为准;
 2. **构造期 fail-fast**——配置拼写错误在引擎启动时抛错,而不是在会话中途悄悄漏进提示词;
 3. **向后兼容**——`buildNudgeText` / `rangeTable` / `ACP_SYSTEM_PROMPT` 的现有导出签名继续可用;
 4. **YAML 友好**——配置必须是 JSON/YAML 可序列化的纯字符串(null 允许,函数不支持)。
@@ -46,12 +53,15 @@ billion-context-dsh 目前所有"模型可见"的提示词文本都是硬编码�
 
 | # | 阶段 | 当前位置 | 内容 | 可用占位符 |
 |---|---|---|---|---|
-| P1 | nudge 普通档首句 | `src/nudge.ts:123` | "Context usage is at X%. This is a suggestion, not a requirement…" | `{pct}` |
-| P2 | nudge 紧急档首句 | `src/nudge.ts:122` | "⚠️ Context usage is at X% of the window — nearly full…" | `{pct}` |
-| P3 | nudge 指导行 | `src/nudge.ts:124` | "Compress by need, not by percentage…" | 无 |
-| P4 | nudge tier 蒸馏行 | `src/nudge.ts:126-136` | "Tier 2: 3 tier-1 block(s) distillable (4750 tokens)…"(数字直出,**无 K 格式化**) | `{tier} {count} {prevTier} {tokens} {seqs}` |
-| P5 | nudge 范围表 | `src/nudge.ts:38-49` | 表头 "Surface: …" + 标题 + 每行 + 表尾调用语法 | 表头 `{surface}`;标题 `{count}`;行 `{start} {end} {count} {tokens}`;表尾无 |
-| P6 | system prompt(一次性) | `src/system-prompt.ts:12` | 整段 ACP 指导(含 kernel 的 `COMPRESS_PHILOSOPHY`) | `{philosophy}` |
+| P1 | nudge 普通档首句 | `src/prompts.ts`(DEFAULT_PROMPTS.nudge.normal) | "Context usage is at X%. This is an efficiency nudge to compress early and keep context lean — not an overflow warning. …"(内嵌 philosophy) | `{pct}` `{philosophy}` |
+| P2 | nudge 紧急档首句 | `src/prompts.ts`(DEFAULT_PROMPTS.nudge.emergency) | "⚠️ Context limit reached — compress now. Prioritize consumed tool outputs."(内嵌 philosophy) | `{pct}` `{philosophy}` |
+| P3 | nudge 指导行 | `src/prompts.ts`(DEFAULT_PROMPTS.nudge.guidance) | kernel `HOW_TO_COMPRESS_RULES` 全文(KEEP/DROP/PRIORITY/格式) | 无 |
+| P4 | nudge tier 蒸馏行 | `src/nudge.ts`(buildNudgeText) | "Tier 2: 1 tier-1 block(s) distillable (4750 tokens) — compress their summary node(s) [seqs …]…" | `{tier} {count} {prevTier} {tokens} {seqs}` |
+| P8 | nudge 上下文分解 | `src/prompts.ts`(DEFAULT_PROMPTS.nudge.breakdown) | "Context breakdown: 0K system \| 134K tool \| 0K summaries \| 10K code \| 7K text"(对齐 kernel `formatBreakdown`) | `{system} {tool} {summaries} {code} {text}` |
+| P9 | nudge 增长行 | `src/prompts.ts`(DEFAULT_PROMPTS.nudge.growth) | "+26K since last nudge" | `{growth}` |
+| P10 | nudge 批量提示 | `src/prompts.ts`(DEFAULT_PROMPTS.nudge.tip) | "💡 Compress all ranges in one call (pass multiple content entries: `content: [{...}, {...}]`)." | 无 |
+| P5 | nudge 范围表 | `src/nudge.ts`(rangeTable) | 表头 "Surface: …" + 标题 + 每行 + 表尾调用语法 | 表头 `{surface}`;标题 `{count}`;行 `{start} {end} {count} {tokens}`;表尾无 |
+| P6 | system prompt(一次性) | `src/system-prompt.ts` | 整段 ACP 指导:效率通知框架 + philosophy + WHEN TO/WHEN NOT + HOW_TO_COMPRESS_RULES + 工具描述 + tier 蒸馏/浓缩规则 | `{philosophy}` `{howToCompressRules}` `{tier2DistillRules}` `{tier3CondenseRules}` |
 | P7 | 工具描述 | `src/tools.ts:355-395` | compress / decompress / search_context / acp_status 的 description | 无 |
 
 ## 3. 核心机制:模板 + 命名占位符
@@ -115,14 +125,20 @@ type PromptInput = string | null
 type PromptOverride<T> = { [K in keyof T]?: PromptInput }
 
 export interface NudgePrompts {
-  /** P1 普通档首句。占位符:{pct} */
+  /** P1 普通档首句。占位符:{pct} {philosophy} */
   normal: string
-  /** P2 紧急档首句。占位符:{pct} */
+  /** P2 紧急档首句。占位符:{pct} {philosophy} */
   emergency: string
-  /** P3 指导行。无占位符 */
+  /** P3 指导行(默认 = kernel HOW_TO_COMPRESS_RULES)。无占位符 */
   guidance: string
   /** P4 tier 蒸馏行。占位符:{tier} {count} {prevTier} {tokens} {seqs} */
   tier: string
+  /** P8 上下文分解。占位符:{system} {tool} {summaries} {code} {text} */
+  breakdown: string
+  /** P9 增长行。占位符:{growth} */
+  growth: string
+  /** P10 批量压缩提示。无占位符 */
+  tip: string
 }
 export interface RangeTablePrompts {
   /** P5 表头。占位符:{surface} */
@@ -183,25 +199,33 @@ export function renderSystemPrompt(prompts: ResolvedPrompts): string { … }
 - **组级 null 防御(W3)**:YAML 宿主可能写 `prompts: { nudge: null }`(键级 null 在 TS 下合法,组级 null 过不了类型但 YAML 无类型检查);`resolvePrompts` 对组级 null 视为**整组用默认**——逐键比较前先做组级归一化;
 - 类型层面 `PromptInput = string | null`,`ResolvedPrompts` 全是 `string`——null 只存在于输入侧,解析后被归一化,消费方永远看到 string。
 
-**空串删除的精确装配语义(I5/N1 定案)——以 nudge 为例,规则逐字节复现现状输出:**
+**空串删除的精确装配语义(I5/N1 定案,叠加 K3 对齐 kernel 后的装配顺序)——以 nudge 为例:**
 
 ```
-nudge 装配(精确复现现状 src/nudge.ts:125-138):
-  parts = [frame]
-  if (guidance 渲染非空)  push('', guidance)   // 分隔空行由这里提供
-  if (tier 条件满足 && tier 行渲染非空)  push(tier 行)  // 紧跟 guidance,单换行分隔(现状 :133-135);tier 空串 = 删除该行(W1)
-  push(rangeTable(session, prompts))            // 无条件 push:零范围返回 '' 也 push(保留现状尾部 '\n')
+nudge 装配(v5,对齐 kernel renderNudgeText 的顺序):
+  parts = [frame]                       // frame = normal/emergency 模板渲染({pct} + {philosophy} 内嵌)
+  if (breakdown 渲染非空)  push('', breakdown)   // P8,来自 nudge.contextBreakdown
+  if (growth 渲染非空)     push(growth)          // P9,仅 contextBreakdown.growth > 0 时渲染
+  if (guidance 渲染非空)  push('', guidance)     // P3 默认 = HOW_TO_COMPRESS_RULES;分隔空行由这里提供
+  if (tier 条件满足 && tier 行渲染非空) {
+    push(tier 行)                              // P4,紧跟 guidance,单换行分隔
+    push('', tierRules)                        // K3:tier nudge 附加 TIER2_DISTILL_RULES / TIER3_CONDENSE_RULES
+  } else {
+    push(rangeTable(session, prompts))          // K3:仅非 tier nudge 渲染范围表;零范围返回 '' 也 push
+  }
+  if (tip 渲染非空)  push('', tip)              // P10 💡 批量提示,对齐 kernel 尾部行
   return parts.join('\n')
 ```
 
-字节对照表(实测现状输出,实现后必须逐字节一致):
+字节对照表(v5;K3 后装配顺序与 v4 不同,tier 分支不再渲染范围表):
 
 | 情形 | 完整字节 |
 |---|---|
-| 默认有范围 | `frame` `\n\n` `guidance` `\n\n` `Surface: …`(guidance 与表头间 1 空行,该空行由范围表内部前导元素提供) |
-| tier + 范围 | `frame` `\n\n` `guidance` `\n` `tierLine` `\n\n` `Surface: …`(tier 紧跟 guidance,单换行;表前空行由范围表前导元素提供) |
-| 零范围 | `frame` `\n\n` `guidance` `\n`(**尾部 `\n` 是字节的一部分**——范围表返回 `''` 仍被 push) |
-| `guidance: ''` | `frame` `\n\n` `Surface: …`(干净删除 guidance;表前空行仍由范围表前导元素提供,共 1 空行) |
+| 默认有范围(非 tier) | `frame` `\n\n` `breakdown` `\n` `growth` `\n\n` `guidance` `\n\n` `Surface: …` `\n\n` `tip`(breakdown/growth/guidance 各带分隔;表前空行由范围表内部前导元素提供) |
+| 无 breakdown/growth | `frame` `\n\n` `guidance` `\n\n` `Surface: …` `\n\n` `tip` |
+| tier nudge | `frame` `\n\n` `breakdown` … `\n\n` `guidance` `\n` `tierLine` `\n\n` `TIER2_DISTILL_RULES…` `\n\n` `tip`(**无范围表**,K3) |
+| 零范围(非 tier) | `frame` `\n\n` `guidance` `\n` `\n` `tip`(范围表返回 `''` 仍被 push,尾部换行是字节的一部分) |
+| `guidance: ''`(有范围) | `frame` `\n\n` `breakdown`… `\n\n` `Surface: …` `\n\n` `tip`(干净删除 guidance;表前空行仍由范围表前导元素提供) |
 | `normal: ''` | 输出以 `\n\n` 开头(实测,S4;允许,文档如此定义) |
 
 **三个最容易写错的细节(N1/W1):**
@@ -211,7 +235,7 @@ nudge 装配(精确复现现状 src/nudge.ts:125-138):
 
 ## 5. 默认值(DEFAULT_PROMPTS)—— 从现有源码逐字搬迁
 
-> 硬约束:以下默认模板渲染结果必须与当前源码输出**逐字节相同**;现有测试(`tests/nudge.test.ts` 断言 `/Tier 2: 1 tier-1 block\(s\) distillable \(4750 tokens\)/`、`/Surface: 12 nodes, seqs 1\.\.12/` 等)全部保持绿色。
+> 硬约束:以下默认模板渲染结果必须与 v5 源码输出**逐字节相同**(K1–K4 是本 PR 的默认文案基线——normal/emergency/guidance/system prompt 已按 kernel/pi 对齐,下方 §5.1/§5.3 即新基线的逐字内容);现有测试(`tests/nudge.test.ts` 断言 `/Tier 2: 1 tier-1 block\(s\) distillable \(4750 tokens\)/`、`/Surface: 12 nodes, seqs 1\.\.12/` 等)全部保持绿色。
 >
 > **实现时与 main v0.1.8 对齐**:本设计定稿于 main v0.1.7 时代,实现 rebase 到 v0.1.8 后,默认文案已同步 main 的新增内容——范围表 footer 追加 stale-seq 提示行(提交 `ea1de6a`)、compress 工具描述追加 stale-remap 句(同提交)、system prompt 的 compress/acp_status 描述行更新(同提交)。下方示例即实现 `DEFAULT_PROMPTS` 的逐字内容。
 
@@ -219,22 +243,30 @@ nudge 装配(精确复现现状 src/nudge.ts:125-138):
 
 ```ts
 nudge: {
-  normal:    'Context usage is at {pct}%. This is a suggestion, not a requirement — you decide whether and when to compress.',
-  emergency: '⚠️ Context usage is at {pct}% of the window — nearly full. Consider compressing consumed ranges soon so working context stays available; the choice and timing are yours.',
-  guidance:  'Compress by need, not by percentage: replace only ranges you have genuinely consumed, with dense self-contained summaries.',
+  normal:    'Context usage is at {pct}%. This is an efficiency nudge to compress early and keep context lean — not an overflow warning. A separate, stronger alert will appear if the context is actually full.\n\n{philosophy}',
+  emergency: '⚠️ Context limit reached — compress now. Prioritize consumed tool outputs.\n\n{philosophy}',
+  guidance:  HOW_TO_COMPRESS_RULES,   // kernel 导入,见 acp-kernel/src/compression-rules.ts
   tier:      'Tier {tier}: {count} tier-{prevTier} block(s) distillable ({tokens} tokens) — compress their summary node(s) [seqs {seqs}] to reclaim the original messages.',
+  breakdown: 'Context breakdown: {system}K system | {tool}K tool | {summaries}K summaries | {code}K code | {text}K text',
+  growth:    '+{growth}K since last nudge',
+  tip:       '💡 Compress all ranges in one call (pass multiple content entries: `content: [{...}, {...}]`).',
 }
 ```
 
 渲染变量映射(调用方 buildNudgeText 负责补齐,配合 §3.2 缺值即抛契约):
 
 - `pct` = `Math.round(Math.min(nudge.contextUsage, 1) * 100)`(封顶 100 的既有逻辑保留);
+- `philosophy` = kernel `COMPRESS_PHILOSOPHY`(K1:普通/紧急档模板内嵌,对齐 kernel `EFFICIENCY_NOTE` / `EMERGENCY_HEADER`);
 - `tier` = `nudge.tier`;`prevTier` = `nudge.tier - 1`;
 - `count` = 目标块数(`nudge.tierTargetBlocks.length`);
-- `tokens` = **`typeof pending === 'number' ? pending : 0`(B2:保留现有守卫,见 src/nudge.ts:131-132)**,其中 `pending = nudge.tier === 2 ? nudge.breakdown?.pendingT2 : nudge.breakdown?.pendingT3`——恒为 number,绝不让 `{tokens}` 渲染成空;
-- `seqs` = `summarySeqs`(已过滤 null)逗号拼接;**全 null 时为空数组 → 渲染为 `''`(定义值,非缺值,不触发 §3.2;`[seqs ]` 与现状一致,S1)**。
+- `tokens` = **`typeof pending === 'number' ? pending : 0`(B2:保留现有守卫,见 src/nudge.ts)**,其中 `pending = nudge.tier === 2 ? nudge.breakdown?.pendingT2 : nudge.breakdown?.pendingT3`——恒为 number,绝不让 `{tokens}` 渲染成空;
+- `seqs` = `summarySeqs`(已过滤 null)逗号拼接;**全 null 时为空数组 → 渲染为 `''`(定义值,非缺值,不触发 §3.2;`[seqs ]` 与现状一致,S1)**;
+- `system/tool/summaries/code/text` = `nudge.contextBreakdown` 对应字段除以 1000 取整(K2,对齐 kernel `formatBreakdown` 的 K 格式化);`growth` = `contextBreakdown.growth / 1000` 取整,仅在 `growth > 0` 时渲染。
 
-**条件渲染规则(I1):** tier 行是**条件块**——仅当 `nudge.tier === 2 || nudge.tier === 3` 且 `tierTargetBlocks` 非空时才渲染(对应现状 src/nudge.ts:126);T1 普通 nudge 无 tier 行。
+**条件渲染规则(I1 保留 + K3 新增):**
+- tier 行是**条件块**——仅当 `nudge.tier === 2 || nudge.tier === 3` 且 `tierTargetBlocks` 非空时才渲染(对应 src/nudge.ts);T1 普通 nudge 无 tier 行;
+- **K3**:tier nudge 在 tier 行后附加 kernel `TIER2_DISTILL_RULES`(tier=2)或 `TIER3_CONDENSE_RULES`(tier=3),且**跳过范围表**——tier 目标块由 tier 行 + 蒸馏规则承载,与 kernel `renderNudgeText` 一致;
+- **breakdown 条件**:仅 `nudge.contextBreakdown` 存在时渲染(K2 新增,普通 nudge 有 breakdown、纯 tier 决策也可能有);`breakdown` 模板渲染为空串则整块省略。
 
 ### 5.2 范围表
 
@@ -260,17 +292,22 @@ rangeTable: {
 
 ### 5.3 system prompt
 
-把现有 `ACP_SYSTEM_PROMPT` 中的 `${COMPRESS_PHILOSOPHY}` 原地换成占位符:
+把现有 `ACP_SYSTEM_PROMPT` 的可变段换成占位符(K4):
 
 ```ts
 systemPromptTemplate:
   'Active Context Pruning — model-driven context management\n\n'
-  + 'YOU decide whether and when to compress context. …(现有全文)…\n\n'
+  + 'YOU decide whether and when to compress context. The nudge is an efficiency notification: …(v5 效率通知框架,去掉了 "Nothing forces you")…\n\n'
   + '{philosophy}\n\n'
-  + 'Compression tools (refs are SURFACE SEQS, not ids):\n…(现有全文)…'
+  + 'WHEN TO COMPRESS:\n- …(7 条场景清单,对齐 pi ACP_SYSTEM_PROMPT)…\n\n'
+  + 'WHEN NOT TO COMPRESS:\n- …(3 条,对齐 pi)…\n\n'
+  + '{howToCompressRules}\n\n'
+  + 'Compression tools (refs are SURFACE SEQS, not ids):\n…(现有全文)…\n\n'
+  + 'Tiered compression: …\n\n{tier2DistillRules}\n\n{tier3CondenseRules}\n\n'
+  + 'When you write a summary, …(现有结尾)…'
 ```
 
-`renderSystemPrompt` 注入 `{philosophy: COMPRESS_PHILOSOPHY}`(kernel 导入保持不变)。
+`renderSystemPrompt` 注入 4 个变量(K5):`{philosophy: COMPRESS_PHILOSOPHY}`、`{howToCompressRules: HOW_TO_COMPRESS_RULES}`、`{tier2DistillRules: TIER2_DISTILL_RULES}`、`{tier3CondenseRules: TIER3_CONDENSE_RULES}`(全部来自 kernel 导入)。
 
 ### 5.4 工具描述
 
@@ -289,9 +326,10 @@ tools: {
 |---|---|
 | `src/prompts.ts`(新) | 类型 + `DEFAULT_PROMPTS` + `DEFAULT_RESOLVED` + `resolvePrompts` + `renderTemplate` + `renderSystemPrompt` |
 | `src/index.ts` | 新增实例字段 `readonly prompts: ResolvedPrompts`(赋值先于 env 构建,S5);`AcpConfig` 加 `readonly prompts?: AcpPrompts`;构造器 `this.prompts = resolvePrompts(config.prompts)`(**fail-fast**);env 带 `prompts: this.prompts`;system prompt section 用 `renderSystemPrompt(this.prompts)`;**顺带修复(I-建议4)**:systemPrompt.section 注册补 `internal/service` 冷启动重试(与同文件 tools/commands 的 registerTools 模式一致,现状 `ctx.get('systemPrompt')` 缺席时 ACP 段落会永久丢失) |
-| `src/nudge.ts` | `NudgeEnvironment` 加 `readonly prompts?: ResolvedPrompts`;**B1 关键行**:`buildNudge` 内 `nudge.ts:100` 的调用改为 `buildNudgeText(nudge, emergency, session, env.prompts)`——这是配置进入 nudge 的**唯一转发点**,漏掉 = 配置被接受但静默失效;`buildNudgeText(nudge, emergency, session, prompts = DEFAULT_RESOLVED)`(可选末参);`rangeTable(session, prompts = DEFAULT_RESOLVED)`;拼装改用模板渲染(§4 装配规则) |
+| `src/nudge.ts` | `NudgeEnvironment` 加 `readonly prompts?: ResolvedPrompts`;**B1 关键行**:`buildNudge` 内 `nudge.ts:100` 的调用改为 `buildNudgeText(nudge, emergency, session, env.prompts)`——这是配置进入 nudge 的**唯一转发点**,漏掉 = 配置被接受但静默失效;`buildNudgeText(nudge, emergency, session, prompts = DEFAULT_RESOLVED)`(可选末参);`rangeTable(session, prompts = DEFAULT_RESOLVED)`;拼装改用模板渲染(**K3 装配顺序**:frame → breakdown → growth → guidance → tier(+tier 规则)/范围表 → tip) |
 | `src/tools.ts` | `ToolEnvironment` 加 `readonly prompts?: ResolvedPrompts`;`makeTools` 里四个 description 从 `env.prompts.tools.*` 取,缺省 `DEFAULT_RESOLVED` |
 | `src/system-prompt.ts` | `ACP_SYSTEM_PROMPT` 改为"默认模板渲染结果"导出(名称与语义不变);模板/渲染逻辑留在 `prompts.ts` |
+| `src/prompts.ts` | **K2**:`NudgePrompts` 新增 `breakdown` / `growth` / `tip` 槽位与默认模板;**K1**:normal/emergency 默认模板对齐 kernel(内嵌 `{philosophy}`);`guidance` 默认 = `HOW_TO_COMPRESS_RULES`;**K4**:systemPromptTemplate 新增 `{howToCompressRules}` / `{tier2DistillRules}` / `{tier3CondenseRules}` 占位符 + WHEN TO/WHEN NOT 段落;**K5**:`renderSystemPrompt` 注入 4 个 kernel 变量 |
 | `AGENTS.md` | 模块图加 `prompts.ts`(M4) |
 | `docs/README.md` | ~~加索引行~~ **已完成**(v1 已收录本设计文档条目) |
 
@@ -303,28 +341,28 @@ tools: {
 - `rangeTable(session)` 不变(第二参可选);
 - `ACP_SYSTEM_PROMPT` / `ACP_SYSTEM_PROMPT_ORDER` 导出不变(`index.ts` 原样 re-export);
 - `AcpConfig` 现有字段全部不动,只新增 `prompts`;
-- 未配置 `prompts` 的部署:行为与现在完全相同(默认模板渲染 = 现文案)。
+- 未配置 `prompts` 的部署:行为与 v5 的默认模板渲染一致(默认文案已对齐 kernel,见 K1–K4;这是**有意的**默认文案变更,不是兼容性破坏——`prompts` 槽位结构向后兼容,v4 部署写的 `nudge.normal` 覆盖仍然有效)。
 
-## 8. 测试计划(新增 13 条 + 现有 54 条回归)
+## 8. 测试计划(v5:77 条回归全绿;§4/§5 快照按新默认文案重写)
 
-> **实现落地**:新增 **15 条**(13 条单元对应下编 #1–#13,另加 2 条引擎级接线)——#14 用 `ctx.provide` 伪造 `systemPrompt`/`tools` + `agent/pre-step` waterfall 验证自定义文案进入注入消息、段落注册恰一次、工具描述自定义;#15 验证引擎构造器对未知占位符同步抛错(fail-fast)、组级 null 容忍。对应提交 `5fff5ae` / `832cbc4`。
+> **v5 实现落地**:`tests/prompts.test.ts` 的 #1/#2/#3/#10/#13 快照按新默认文案重写——#1 由整串字节对比改为"关键段落存在 + 旧语气缺席"(system prompt 变长且含 kernel 规则,整串快照维护成本高);#2/#3 改为断言 efficiency-note 首句、philosophy 内嵌、HOW_TO_COMPRESS_RULES 存在、💡 tip 结尾、旧文案缺席;#10 空串删除用例同时置空 breakdown/growth/tip 以验证干净装配;新增 breakdown/growth 槽位渲染断言(中文覆盖冒烟 #13 同步扩展)。
 
 > **快照原则(I3/I4):** 所有"逐字节回归"断言用**硬编码在测试里的字面量**(实现改造前抄下来的当前输出),与实现分离——测试与实现不同源,改造引入的字节差异(em-dash、⚠️、尾部空格、换行)都会被抓住。不依赖"改造后的 ACP_SYSTEM_PROMPT 导出"作比较(那是循环论证)。
 
-1. **system prompt 快照回归**:`renderSystemPrompt(resolvePrompts())` === 硬编码的当前 `ACP_SYSTEM_PROMPT` 全文字面量;
-2. **nudge 普通档全文本快照**:`buildNudgeText` 以 `pct=7` 渲染,**零范围会话**(范围表返回 `''`)→ 完整字节 === 硬编码字面量 `frame + '\n\n' + guidance + '\n'`(**尾部 `\n` 是字节的一部分,必须保留**;用 `assert.equal` 整串比较,N3);
-3. **nudge 紧急档全文本快照**:`pct=96` 紧急档,零范围会话,完整字节 === 硬编码字面量(含 ⚠️ 与连字符、尾部 `\n`);
+1. **system prompt 快照回归**:`renderSystemPrompt(resolvePrompts())` === 硬编码的当前 `ACP_SYSTEM_PROMPT` 全文字面量(v5 改为**关键段落断言**:首段效率通知框架、philosophy、WHEN TO/WHEN NOT、HOW TO COMPRESS、四工具描述、tier 规则、结尾规则——避免整串快照随 kernel 规则文本漂移);
+2. **nudge 普通档全文本快照**:`buildNudgeText` 以 `pct=7` 渲染,**零范围会话** → 断言 efficiency-note 首句 + philosophy 内嵌 + HOW_TO_COMPRESS_RULES + 💡 tip 结尾 + 无 "suggestion, not a requirement";
+3. **nudge 紧急档全文本快照**:`pct=96` 紧急档 → 断言 "⚠️ Context limit reached — compress now" 首句 + philosophy 内嵌 + HOW_TO_COMPRESS_RULES + 💡 tip 结尾 + 无 "choice and timing are yours";
 4. **范围表快照**:`rangeTable` 对固定 session 的完整输出 === 硬编码字面量(含前导空行);另加**零范围回归**:无可压缩范围时返回 `''`;
 5. **工具描述快照**:四个 description === 硬编码字面量;
 6. **深合并 + null 归一化**:只覆盖 `nudge.normal`,其余槽位仍是默认;`guidance: null` → 默认(B3);
 7. **占位符替换**:`normal: '上下文 {pct}%'` 渲染出正确百分比;
 8. **未知占位符抛错**:`normal: '…{pctt}…'` → throw,错误信息含槽位路径 `prompts.nudge.normal`;
 9. **已知占位符缺值抛错(I6)**:`renderTemplate('{tokens}', {})` → throw;
-10. **空串删除行(I5/N1)**:`guidance: ''` 的 nudge(有范围会话)完整字节 === `frame + '\n' + rangeTable`——不含 guidance 文本,表前恰 1 空行(由范围表前导元素提供);
+10. **空串删除行(I5/N1)**:`guidance: ''` + `breakdown: ''` + `growth: ''` + `tip: ''` 的 nudge(有范围会话)完整字节 === `frame + '\n' + rangeTable`——不含 guidance/breakdown/tip 文本,表前恰 1 空行(由范围表前导元素提供);
 11. **tokens 兜底回归(B2)**:pending 缺失(pendingT2/pendingT3 为 undefined)的 tier nudge 渲染出 `(0 tokens)` 而非 `( tokens)`;**注(S3)**:`NudgeBreakdown.pendingT2/pendingT3` 在 acp-kernel 类型里是**必填** number(types.d.ts:183-185),测试构造缺省时需类型断言(项目无 `as any`,用 `as never`/省略字段 cast,与现有 nudge.test.ts:117 同法);
 12. **接线集成测试(B1)**:构造带 `prompts: resolvePrompts({ nudge: { normal: 'CUSTOM {pct}' } })` 的 env → `buildNudge` → 注入消息以 `CUSTOM` 开头(转发缺失时是默认文案,测试红);
-13. **中文覆盖冒烟**:整套中文 nudge + 范围表 + system prompt 渲染,断言关键中文子串(i18n 场景可用);
-14. **回归**:现有 54 条测试全部保持绿色(它们断言了默认文本子串,见 §5 硬约束)。
+13. **中文覆盖冒烟**:整套中文 nudge + 范围表 + system prompt 渲染,断言关键中文子串(i18n 场景可用;**v5 扩展**:中文覆盖新增 breakdown/growth/tip 槽位 + `{howToCompressRules}` 占位符);
+14. **回归**:现有 77 条测试全部保持绿色(它们断言了默认文本子串,见 §5 硬约束)。
 
 验收命令:`npm run typecheck && npm test && npm run build`。
 

--- a/docs/configurable-prompts-design.md
+++ b/docs/configurable-prompts-design.md
@@ -53,7 +53,7 @@ billion-context-dsh 目前所有"模型可见"的提示词文本都是硬编码�
 
 | # | 阶段 | 当前位置 | 内容 | 可用占位符 |
 |---|---|---|---|---|
-| P1 | nudge 普通档首句 | `src/prompts.ts`(DEFAULT_PROMPTS.nudge.normal) | "Context usage is at X%. This is an efficiency nudge to compress early and keep context lean — not an overflow warning. …"(内嵌 philosophy) | `{pct}` `{philosophy}` |
+| P1 | nudge 普通档首句 | `src/prompts.ts`(DEFAULT_PROMPTS.nudge.normal) | kernel `EFFICIENCY_NOTE` 逐字——"This is an efficiency nudge to compress early and keep context lean — not an overflow warning. …"(内嵌 philosophy;**不含 "Context usage is at X%" 陈述**,usage 只通过 breakdown 传达) | `{pct}` `{philosophy}` |
 | P2 | nudge 紧急档首句 | `src/prompts.ts`(DEFAULT_PROMPTS.nudge.emergency) | "⚠️ Context limit reached — compress now. Prioritize consumed tool outputs."(内嵌 philosophy) | `{pct}` `{philosophy}` |
 | P3 | nudge 指导行 | `src/prompts.ts`(DEFAULT_PROMPTS.nudge.guidance) | kernel `HOW_TO_COMPRESS_RULES` 全文(KEEP/DROP/PRIORITY/格式) | 无 |
 | P4 | nudge tier 蒸馏行 | `src/nudge.ts`(buildNudgeText) | "Tier 2: 1 tier-1 block(s) distillable (4750 tokens) — compress their summary node(s) [seqs …]…" | `{tier} {count} {prevTier} {tokens} {seqs}` |
@@ -243,7 +243,7 @@ nudge 装配(v5,对齐 kernel renderNudgeText 的顺序):
 
 ```ts
 nudge: {
-  normal:    'Context usage is at {pct}%. This is an efficiency nudge to compress early and keep context lean — not an overflow warning. A separate, stronger alert will appear if the context is actually full.\n\n{philosophy}',
+  normal:    'This is an efficiency nudge to compress early and keep context lean — not an overflow warning. A separate, stronger alert will appear if the context is actually full.\n\n{philosophy}',
   emergency: '⚠️ Context limit reached — compress now. Prioritize consumed tool outputs.\n\n{philosophy}',
   guidance:  HOW_TO_COMPRESS_RULES,   // kernel 导入,见 acp-kernel/src/compression-rules.ts
   tier:      'Tier {tier}: {count} tier-{prevTier} block(s) distillable ({tokens} tokens) — compress their summary node(s) [seqs {seqs}] to reclaim the original messages.',

--- a/src/nudge.ts
+++ b/src/nudge.ts
@@ -7,6 +7,9 @@
  */
 
 import {
+  COMPRESS_PHILOSOPHY,
+  TIER2_DISTILL_RULES,
+  TIER3_CONDENSE_RULES,
   defaultCountTokens,
   type CompressionCore,
   type CoreMessage,
@@ -147,9 +150,11 @@ export function buildNudge(
 }
 
 /**
- * A short ADVISORY nudge — ACP is model-driven, the model decides whether and
- * when to compress. Full guidance (tools, philosophy, summary rules) lives in
- * the system prompt once, not in every nudge.
+ * Render the nudge message text — aligned with the kernel/billion-context-pi
+ * style: efficiency note + philosophy, context breakdown, HOW_TO_COMPRESS_RULES,
+ * then the DSH-specific seq-based range table and the batch-compress tip.
+ * The range table is our own (seq-based, not ref-ID-based) because DSH has no
+ * in-memory message rewrite hook — see docs/dsh-porting-verification.md.
  */
 export function buildNudgeText(
   nudge: NudgeDecision,
@@ -162,12 +167,31 @@ export function buildNudgeText(
   const pct = Math.round(Math.min(nudge.contextUsage, 1) * 100)
   const frame = renderTemplate(
     emergency ? prompts.nudge.emergency : prompts.nudge.normal,
-    { pct },
+    { pct, philosophy: COMPRESS_PHILOSOPHY },
   )
-  // §4 装配规则(逐字节复现现状):frame → guidance(带空行分隔)→ tier(紧跟单换行)
-  // → 范围表(无条件 push,零范围 '' 也 push,保留尾部 '\n')。
   const parts: string[] = [frame]
+
+  // Context breakdown (kernel style, from NudgeDecision.contextBreakdown).
+  if (nudge.contextBreakdown) {
+    const bd = nudge.contextBreakdown
+    const breakdown = renderTemplate(prompts.nudge.breakdown, {
+      system: Math.round(bd.system / 1000),
+      tool: Math.round(bd.tool / 1000),
+      summaries: Math.round(bd.summaries / 1000),
+      code: Math.round(bd.code / 1000),
+      text: Math.round(bd.text / 1000),
+    })
+    if (breakdown !== '') parts.push('', breakdown)
+    if (bd.growth > 0) {
+      const growth = renderTemplate(prompts.nudge.growth, { growth: Math.round(bd.growth / 1000) })
+      if (growth !== '') parts.push(growth)
+    }
+  }
+
+  // HOW_TO_COMPRESS_RULES as guidance (kernel puts it in every nudge).
   if (prompts.nudge.guidance !== '') parts.push('', prompts.nudge.guidance)
+
+  // Tier line (distillation / condensation suggestion) + tier-specific rules.
   if ((nudge.tier === 2 || nudge.tier === 3) && (nudge.tierTargetBlocks?.length ?? 0) > 0) {
     const targets = nudge.tierTargetBlocks!
     const summarySeqs = targets
@@ -182,9 +206,17 @@ export function buildNudgeText(
       tokens,
       seqs: summarySeqs.join(', '),
     })
-    // tier 空串 = 删除该行(W1):默认模板恒渲染非空,对默认字节零影响。
     if (tierLine !== '') parts.push(tierLine)
+    // Tier-specific rules from kernel (TIER2_DISTILL_RULES / TIER3_CONDENSE_RULES).
+    const tierRules = nudge.tier === 2 ? TIER2_DISTILL_RULES : TIER3_CONDENSE_RULES
+    parts.push('', tierRules)
+  } else {
+    // Range table for non-tier nudges (DSH-specific: seq-based, not ref-ID-based).
+    parts.push(rangeTable(session, prompts))
   }
-  parts.push(rangeTable(session, prompts))
+
+  // Batch-compress tip (from kernel's nudge-text.ts style).
+  if (prompts.nudge.tip !== '') parts.push('', prompts.nudge.tip)
+
   return parts.join('\n')
 }

--- a/src/nudge.ts
+++ b/src/nudge.ts
@@ -11,6 +11,7 @@ import {
   TIER2_DISTILL_RULES,
   TIER3_CONDENSE_RULES,
   defaultCountTokens,
+  renderNudgeText,
   type CompressionCore,
   type CoreMessage,
   type NudgeDecision,
@@ -150,17 +151,128 @@ export function buildNudge(
 }
 
 /**
- * Render the nudge message text — aligned with the kernel/billion-context-pi
- * style: efficiency note + philosophy, context breakdown, HOW_TO_COMPRESS_RULES,
- * then the DSH-specific seq-based range table and the batch-compress tip.
- * The range table is our own (seq-based, not ref-ID-based) because DSH has no
- * in-memory message rewrite hook — see docs/dsh-porting-verification.md.
+ * Render the nudge message text. DEFAULT (no `config.prompts.nudge` override)
+ * calls the kernel's own `renderNudgeText` — EFFICIENCY_NOTE/EMERGENCY_HEADER,
+ * context breakdown, HOW_TO_COMPRESS_RULES, tier rules, and the batch tip all
+ * come from acp-kernel verbatim (the kernel-alignment principle). Only the
+ * ref-ID-oriented segments are replaced with our seq-based equivalents,
+ * because DSH has no `<acp>` ref tags — see docs/dsh-porting-verification.md:
+ * - `rangesStr` (mNNNNN refs) → the surface-seq range table;
+ * - the emergency JSON example (startId/endId) → a seq example;
+ * - the tier trigger block (block ids bN) → our tier line with surface seqs.
+ * When a host overrides any `prompts.nudge` slot, the template path is used so
+ * `config.prompts` keeps full control (custom copy wins over kernel defaults).
  */
 export function buildNudgeText(
   nudge: NudgeDecision,
   emergency: boolean,
   session: import('@deepseek-ai/dsh-session').Session,
   prompts: ResolvedPrompts = DEFAULT_RESOLVED,
+): string {
+  // A host override of any nudge slot → template rendering (config.prompts
+  // keeps its v0.1.9 contract: custom copy wins). Only the pristine default
+  // reference reaches the kernel path.
+  if (prompts.nudge !== DEFAULT_RESOLVED.nudge) {
+    return renderNudgeFromTemplates(nudge, emergency, session, prompts)
+  }
+  const rendered = renderNudgeText(nudge)
+  return adaptKernelNudgeToSeq(rendered.text, nudge, session, prompts)
+}
+
+/**
+ * Take the kernel-rendered nudge text and replace its ref-ID-oriented segments
+ * with our surface-seq equivalents. Everything else (frame, philosophy,
+ * breakdown, HOW_TO_COMPRESS_RULES, tier rules, tip) stays kernel verbatim.
+ */
+function adaptKernelNudgeToSeq(
+  text: string,
+  nudge: NudgeDecision,
+  session: import('@deepseek-ai/dsh-session').Session,
+  prompts: ResolvedPrompts,
+): string {
+  let out = text
+  // Tier nudges: replace the kernel trigger block (block ids bN) with our tier
+  // line carrying surface seqs. The kernel's TIER2/3 rules stay in the tail.
+  if ((nudge.tier === 2 || nudge.tier === 3) && (nudge.tierTargetBlocks?.length ?? 0) > 0) {
+    out = replaceTierTrigger(out, nudge, session, prompts)
+  } else if (out.includes('"startId"')) {
+    // Emergency nudges: replace the ref-ID JSON example with a seq example.
+    out = replaceEmergencyExample(out)
+  }
+  // Replace the ref-ID range table (mNNNNN) with the surface-seq table.
+  // A zero-range table leaves the kernel's own "[No specific ranges detected]"
+  // notice intact — it is a better prompt than an empty table.
+  const seqTable = rangeTable(session, prompts)
+  if (seqTable !== '') out = replaceRangesStr(out, seqTable)
+  return out
+}
+
+/** Replace the kernel rangesStr segment (`Compressible ranges (N, oldest first):…`) with our seq table. */
+function replaceRangesStr(text: string, seqTable: string): string {
+  const match = text.match(/\n\n(?:Compressible ranges \(|\[No specific ranges detected)/)
+  if (!match) return text
+  const start = match.index!
+  const rest = text.slice(start + 2)
+  const next = rest.match(/\n\n/)
+  const end = next !== null ? start + 2 + next.index! : text.length
+  const before = text.slice(0, start)
+  const after = text.slice(end)
+  // seqTable starts with '\n' (the range table's leading blank line), so
+  // `before` + '\n' + seqTable yields one blank line before the table.
+  return before + '\n' + seqTable + after
+}
+
+/** Replace the kernel tier trigger segment (`[TIER n …TRIGGER]…Example: compress(…)`) with our tier line. */
+function replaceTierTrigger(
+  text: string,
+  nudge: NudgeDecision,
+  session: import('@deepseek-ai/dsh-session').Session,
+  prompts: ResolvedPrompts,
+): string {
+  const start = text.search(/\n\n(?:\[TIER \d|\[EMERGENCY — TIER \d)/)
+  if (start === -1) return text
+  const rest = text.slice(start + 2)
+  const next = rest.match(/\n\nHOW TO COMPRESS/)
+  const end = next !== null ? start + 2 + next.index! : text.length
+  const targets = nudge.tierTargetBlocks!
+  const summarySeqs = targets
+    .map((block) => summarySeqOfKernelBlock(session, block.blockId))
+    .filter((seq): seq is number => seq !== null)
+  const pending = nudge.tier === 2 ? nudge.breakdown?.pendingT2 : nudge.breakdown?.pendingT3
+  const tokens = typeof pending === 'number' ? pending : 0
+  const tierValue = nudge.tier === null ? 2 : nudge.tier
+  const tierLine = renderTemplate(prompts.nudge.tier, {
+    tier: tierValue,
+    count: targets.length,
+    prevTier: tierValue - 1,
+    tokens,
+    seqs: summarySeqs.join(', '),
+  })
+  return text.slice(0, start) + '\n\n' + tierLine + text.slice(end)
+}
+
+/** Replace the kernel emergency JSON example (startId/endId) with a seq example. */
+function replaceEmergencyExample(text: string): string {
+  const start = text.search(/\n\n\{ "topic":/)
+  if (start === -1) return text
+  const rest = text.slice(start + 2)
+  const next = rest.match(/\n\nCompressible ranges |\n\n\[No specific/)
+  const end = next !== null ? start + 2 + next.index! : text.length
+  return text.slice(0, start)
+    + '\n\ncompress({ content: [{ startSeq, endSeq, summary }] }) — use the seqs from the range table above.'
+    + text.slice(end)
+}
+
+/**
+ * Template rendering path (used only when a host overrides a `prompts.nudge`
+ * slot). Kept byte-compatible with the pre-refactor assembly: frame → breakdown
+ * → growth → guidance → tier(+rules)/range table → tip.
+ */
+function renderNudgeFromTemplates(
+  nudge: NudgeDecision,
+  emergency: boolean,
+  session: import('@deepseek-ai/dsh-session').Session,
+  prompts: ResolvedPrompts,
 ): string {
   // Cap the reported percentage at 100: a broken measurement (e.g. response
   // pressure folded in) must never surface as an absurd "230%" to the model.

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -188,7 +188,9 @@ export function renderSystemPrompt(prompts: ResolvedPrompts): string {
  */
 export const DEFAULT_PROMPTS: ResolvedPrompts = {
   nudge: {
-    normal: 'Context usage is at {pct}%. This is an efficiency nudge to compress early and keep context lean — not an overflow warning. A separate, stronger alert will appear if the context is actually full.\n\n{philosophy}',
+    // 与 kernel nudge-text.ts EFFICIENCY_NOTE 逐字对齐——不含 "Context usage is at X%"
+    // 陈述(usage 只通过 breakdown 传达);{pct} 仍可用作自定义占位符。
+    normal: 'This is an efficiency nudge to compress early and keep context lean — not an overflow warning. A separate, stronger alert will appear if the context is actually full.\n\n{philosophy}',
     emergency: '⚠️ Context limit reached — compress now. Prioritize consumed tool outputs.\n\n{philosophy}',
     guidance: HOW_TO_COMPRESS_RULES,
     tier: 'Tier {tier}: {count} tier-{prevTier} block(s) distillable ({tokens} tokens) — compress their summary node(s) [seqs {seqs}] to reclaim the original messages.',

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -16,7 +16,7 @@
  * @module billion-context-dsh/prompts
  */
 
-import { COMPRESS_PHILOSOPHY } from 'acp-kernel'
+import { COMPRESS_PHILOSOPHY, HOW_TO_COMPRESS_RULES, TIER2_DISTILL_RULES, TIER3_CONDENSE_RULES } from 'acp-kernel'
 
 /** 用户可写值:字符串模板,或 null(= 用默认,等价于不写)。YAML 宿主写 null 是合法输入。 */
 export type PromptInput = string | null
@@ -25,14 +25,20 @@ export type PromptInput = string | null
 export type PromptOverride<T> = { [K in keyof T]?: PromptInput }
 
 export interface NudgePrompts {
-  /** 普通档首句。占位符:{pct} */
+  /** 普通档首句。占位符:{pct} {philosophy} */
   normal: string
-  /** 紧急档首句。占位符:{pct} */
+  /** 紧急档首句。占位符:{pct} {philosophy} */
   emergency: string
-  /** 指导行。无占位符 */
+  /** 指导行（HOW_TO_COMPRESS_RULES）。无占位符 */
   guidance: string
   /** tier 蒸馏行。占位符:{tier} {count} {prevTier} {tokens} {seqs} */
   tier: string
+  /** 上下文分解。占位符:{system} {tool} {summaries} {code} {text} */
+  breakdown: string
+  /** 增长行。占位符:{growth} */
+  growth: string
+  /** 溢出提示。无占位符 */
+  tip: string
 }
 
 export interface RangeTablePrompts {
@@ -73,10 +79,13 @@ export interface ResolvedPrompts {
 
 /** 每槽允许的占位符名集合(构建期校验用)。 */
 const NUDGE_ALLOWED: { [K in keyof NudgePrompts]: ReadonlySet<string> } = {
-  normal: new Set(['pct']),
-  emergency: new Set(['pct']),
+  normal: new Set(['pct', 'philosophy']),
+  emergency: new Set(['pct', 'philosophy']),
   guidance: new Set(),
   tier: new Set(['tier', 'count', 'prevTier', 'tokens', 'seqs']),
+  breakdown: new Set(['system', 'tool', 'summaries', 'code', 'text']),
+  growth: new Set(['growth']),
+  tip: new Set(),
 }
 const RANGE_TABLE_ALLOWED: { [K in keyof RangeTablePrompts]: ReadonlySet<string> } = {
   header: new Set(['surface']),
@@ -90,7 +99,7 @@ const TOOLS_ALLOWED: { [K in keyof ToolPrompts]: ReadonlySet<string> } = {
   searchContext: new Set(),
   acpStatus: new Set(),
 }
-const SYSTEM_ALLOWED = new Set(['philosophy'])
+const SYSTEM_ALLOWED = new Set(['philosophy', 'howToCompressRules', 'tier2DistillRules', 'tier3CondenseRules'])
 
 /** 校验单个模板:未知 `{ident}` → throw(带槽位路径)。默认模板开发期已核验,不重扫。 */
 function validateTemplate(template: string, allowed: ReadonlySet<string>, path: string): string {
@@ -163,9 +172,14 @@ export function resolvePrompts(input?: AcpPrompts): ResolvedPrompts {
   }
 }
 
-/** 渲染 system prompt 模板(注入 kernel 压缩哲学)。 */
+/** 渲染 system prompt 模板(注入 kernel 压缩哲学、压缩规则、蒸馏规则)。 */
 export function renderSystemPrompt(prompts: ResolvedPrompts): string {
-  return renderTemplate(prompts.systemPromptTemplate, { philosophy: COMPRESS_PHILOSOPHY })
+  return renderTemplate(prompts.systemPromptTemplate, {
+    philosophy: COMPRESS_PHILOSOPHY,
+    howToCompressRules: HOW_TO_COMPRESS_RULES,
+    tier2DistillRules: TIER2_DISTILL_RULES,
+    tier3CondenseRules: TIER3_CONDENSE_RULES,
+  })
 }
 
 /**
@@ -174,10 +188,13 @@ export function renderSystemPrompt(prompts: ResolvedPrompts): string {
  */
 export const DEFAULT_PROMPTS: ResolvedPrompts = {
   nudge: {
-    normal: 'Context usage is at {pct}%. This is a suggestion, not a requirement — you decide whether and when to compress.',
-    emergency: '⚠️ Context usage is at {pct}% of the window — nearly full. Consider compressing consumed ranges soon so working context stays available; the choice and timing are yours.',
-    guidance: 'Compress by need, not by percentage: replace only ranges you have genuinely consumed, with dense self-contained summaries.',
+    normal: 'Context usage is at {pct}%. This is an efficiency nudge to compress early and keep context lean — not an overflow warning. A separate, stronger alert will appear if the context is actually full.\n\n{philosophy}',
+    emergency: '⚠️ Context limit reached — compress now. Prioritize consumed tool outputs.\n\n{philosophy}',
+    guidance: HOW_TO_COMPRESS_RULES,
     tier: 'Tier {tier}: {count} tier-{prevTier} block(s) distillable ({tokens} tokens) — compress their summary node(s) [seqs {seqs}] to reclaim the original messages.',
+    breakdown: 'Context breakdown: {system}K system | {tool}K tool | {summaries}K summaries | {code}K code | {text}K text',
+    growth: '+{growth}K since last nudge',
+    tip: '💡 Compress all ranges in one call (pass multiple content entries: `content: [{...}, {...}]`).',
   },
   rangeTable: {
     header: 'Surface: {surface}',
@@ -194,9 +211,25 @@ export const DEFAULT_PROMPTS: ResolvedPrompts = {
   },
   systemPromptTemplate: `Active Context Pruning — model-driven context management
 
-YOU decide whether and when to compress context. Nothing forces you: the injected "nudge" is a suggestion, not an order, and you may ignore it when compression would not help. Compress only ranges you have genuinely consumed (read tool outputs, finished explorations, superseded steps) that the current work no longer needs verbatim.
+YOU decide whether and when to compress context. The nudge is an efficiency notification: when you see one, consider which ranges you have genuinely consumed and could summarise to keep working context lean.
 
 {philosophy}
+
+WHEN TO COMPRESS:
+- A sub-agent or delegated task has returned a large result that you have already extracted the key facts from.
+- Verbose command output (build/test logs, git diff, directory listings) where you have already used the information you need.
+- Exploration that led nowhere.
+- Repeated reads of the same file or repeated status checks once the decision is recorded.
+- Resolved discussion threads where a decision has been captured in summary or in code.
+- Intermediate steps of a completed multi-step task, once the final result is recorded.
+- A task phase has ended — bug hunt complete, root cause found, exploration done, research sprint wrapped.
+
+WHEN NOT TO COMPRESS:
+- Content the current step is actively reading or reasoning about.
+- Important user messages — preserve their exact intent, constraints, and acceptance criteria.
+- Protected tool outputs — hard-excluded from compression ranges, survive intact in visible context.
+
+{howToCompressRules}
 
 Compression tools (refs are SURFACE SEQS, not ids):
 - compress: replace one or more seq ranges, each with your own dense summary. Single range: compress({ content: [{ startSeq, endSeq, summary }] }). Batch multiple unrelated segments in one call (each entry becomes its own block): compress({ content: [{ startSeq: 1, endSeq: 5, summary: '...' }, { startSeq: 12, endSeq: 18, summary: '...' }] }). Keep ranges disjoint — overlapping entries in one batch are skipped. Edges are auto-balanced to tool-call/result boundaries; a trailing #callId fragment in a seq is ignored. Seq refs must be on the current surface: seqs from older nudges or earlier compresses go stale as the surface moves, so a stale span is auto-remapped to its still-live remainder (the result reports the adjusted span), a fully compressed span is reported as already compressed, and invented/other-session seqs fail with guidance.
@@ -205,6 +238,10 @@ Compression tools (refs are SURFACE SEQS, not ids):
 - acp_status: current context usage and the live compressible-range list. Run it right before compressing — the only seqs that never go stale are the ones you just read.
 
 Tiered compression: each compressed block appears on the surface as one summary node. Compressing that node again DISTILLS the block (tier 2): the parent summary folds into your new summary and the original messages are freed. Distilling a tier-2 block yields tier 3. Distill when a summary itself is consumed — decompress on the tier-2 block recovers the full originals.
+
+{tier2DistillRules}
+
+{tier3CondenseRules}
 
 When you write a summary, it becomes the ONLY record of that range: keep file paths, signatures, exact values, decisions, and error strings verbatim so a later reader (or you, after decompress) can continue without the original. Never reuse historical seqs — the surface moves as messages land and compress; verify with acp_status.`,
 }

--- a/src/system-prompt.ts
+++ b/src/system-prompt.ts
@@ -3,11 +3,11 @@
  * ACP_SYSTEM_PROMPT): the load-bearing compression guidance lives here, ONCE,
  * instead of being re-sent with every nudge. The nudge itself stays a short,
  * advisory notice — ACP is model-driven, the model decides whether and when
- * to compress (never "compress now").
+ * to compress.
  *
  * The text is DEFAULT_PROMPTS.systemPromptTemplate rendered with the kernel's
- * COMPRESS_PHILOSOPHY; hosts can override the whole section via
- * `config.prompts.systemPrompt` (see docs/configurable-prompts-design.md).
+ * COMPRESS_PHILOSOPHY and HOW_TO_COMPRESS_RULES; hosts can override the whole
+ * section via `config.prompts.systemPrompt` (see docs/configurable-prompts-design.md).
  * @module billion-context-dsh/system-prompt
  */
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -67,11 +67,22 @@ function requireAgent(exec: ToolRunContext): Agent {
 }
 
 const compressParameters = {
+  // Tolerated wrapped-arguments form: some models emit
+  // `{ "arguments": "{\"content\": [...]}" }` (double-nested) or
+  // `{ "arguments": { "content": [...] } }` instead of the unwrapped
+  // `{ "content": [...] }`. The old DSH validator surfaced this as
+  // `invalid arguments: "arguments" must be an object` and the model retried
+  // forever. `arguments` is accepted as an optional JSON node so the wrapped
+  // shape passes schema validation; `handleCompress` unwraps it and falls back
+  // to a clear runtime error when neither form carries content. `content` is
+  // intentionally NOT `required: true` — a required property would reject the
+  // wrapped shape before `handleCompress` can see it. The tool description
+  // still tells the model content is mandatory.
+  arguments: { type: 'json', description: 'Tolerated wrapped-arguments form (model-generated); unwrapped in handleCompress. Prefer passing content directly.' },
   topic: { type: 'string' as const, description: 'Fallback topic for entries without their own.' },
   content: {
     type: 'array' as const,
-    required: true,
-    description: 'One or more ranges to compress, each with startSeq/endSeq boundaries (surface seqs) and a dense summary.',
+    description: 'One or more ranges to compress, each with startSeq/endSeq boundaries (surface seqs) and a dense summary. Required — pass it directly, not wrapped in an arguments key.',
     items: {
       type: 'object' as const,
       properties: {
@@ -106,8 +117,33 @@ function parseSeq(value: number | string): number {
 }
 
 interface CompressArgs {
+  /** Tolerated wrapped-arguments form (model-generated double-nesting). */
+  arguments?: string | { content?: CompressArgs['content'] }
   topic?: string
-  content: Array<{ startSeq: number | string; endSeq: number | string; summary: string; topic?: string }>
+  content?: Array<{ startSeq: number | string; endSeq: number | string; summary: string; topic?: string }>
+}
+
+/**
+ * Unwrap the tolerated wrapped-arguments forms back to the canonical shape:
+ * `{ arguments: "{\"content\": [...]}" }` or `{ arguments: { content: [...] } }`
+ * → `{ content: [...] }`. The direct `{ content: [...] }` form passes through
+ * untouched. Returns null when no form carries content (caller raises).
+ */
+function unwrapCompressArgs(args: CompressArgs): CompressArgs | null {
+  if (args.content !== undefined) return args
+  if (args.arguments === undefined) return null
+  let inner: unknown = args.arguments
+  if (typeof inner === 'string') {
+    try {
+      inner = JSON.parse(inner)
+    } catch {
+      return null
+    }
+  }
+  if (typeof inner !== 'object' || inner === null || Array.isArray(inner)) return null
+  const content = (inner as { content?: unknown }).content
+  if (content === undefined) return null
+  return { ...args, content: content as CompressArgs['content'] }
 }
 
 /** Resolve seq → kernel ref, then applyCompression and land the transaction. */
@@ -130,6 +166,17 @@ async function handleCompress(env: ToolEnvironment, args: CompressArgs, exec: To
   env.store.set(session, turn.state)
   const byRaw = turn.state.messageRefs.byRaw
 
+  // Tolerate the wrapped-arguments forms some models emit (double-nested
+  // `{ arguments: "..." }`), which the old DSH validator surfaced as
+  // `"arguments" must be an object` and sent the model into a retry loop.
+  const unwrapped = unwrapCompressArgs(args)
+  if (unwrapped === null) {
+    return {
+      text: 'compress: missing content — pass the content array directly: compress({ content: [{ startSeq, endSeq, summary }] })',
+    }
+  }
+  args = unwrapped
+
   const ranges: Array<
     ResolvedSurfaceRange & {
       startSeq: number
@@ -143,7 +190,7 @@ async function handleCompress(env: ToolEnvironment, args: CompressArgs, exec: To
   // Ranges whose whole span was already shadowed by earlier compressions.
   // They land as advisory warnings, never as errors or phantom blocks.
   const alreadyCompressedNotes: string[] = []
-  for (const range of args.content) {
+  for (const range of args.content!) {
     const startSeq = parseSeq(range.startSeq)
     const endSeq = parseSeq(range.endSeq)
     let resolved: ResolvedSurfaceRange

--- a/tests/prompts.test.ts
+++ b/tests/prompts.test.ts
@@ -65,47 +65,65 @@ function fakeDecision(pct: number, emergency: boolean): NudgeDecision {
   } as never
 }
 
-/** 快照 1:改造前 ACP_SYSTEM_PROMPT 的逐字节字面量(与实现分离,防循环论证)。 */
-const SYSTEM_PROMPT_SNAPSHOT = `Active Context Pruning — model-driven context management
+/** 快照前段:system prompt 去掉"Nothing forces you"后的首段。 */
+const SYSTEM_PROMPT_HEAD = `Active Context Pruning — model-driven context management
 
-YOU decide whether and when to compress context. Nothing forces you: the injected "nudge" is a suggestion, not an order, and you may ignore it when compression would not help. Compress only ranges you have genuinely consumed (read tool outputs, finished explorations, superseded steps) that the current work no longer needs verbatim.
+YOU decide whether and when to compress context. The nudge is an efficiency notification: when you see one, consider which ranges you have genuinely consumed and could summarise to keep working context lean.`
 
-Compression Philosophy:
-- All compression serves the primary task, but be frugal.
-- Context capacity is precious. Save context by compressing consumed outputs, not by avoiding tools.
-- Compress by need, not by percentage.
-- Work from summaries, not raw tool outputs. All listed ranges (user prompts, tool outputs, code, logs, exploration, intermediate steps) should be compressed to summary format — the ONLY exceptions are protected content, content the current step is actively using, or critical content you cannot reconstruct.
-
-Compression tools (refs are SURFACE SEQS, not ids):
-- compress: replace one or more seq ranges, each with your own dense summary. Single range: compress({ content: [{ startSeq, endSeq, summary }] }). Batch multiple unrelated segments in one call (each entry becomes its own block): compress({ content: [{ startSeq: 1, endSeq: 5, summary: '...' }, { startSeq: 12, endSeq: 18, summary: '...' }] }). Keep ranges disjoint — overlapping entries in one batch are skipped. Edges are auto-balanced to tool-call/result boundaries; a trailing #callId fragment in a seq is ignored. Seq refs must be on the current surface: seqs from older nudges or earlier compresses go stale as the surface moves, so a stale span is auto-remapped to its still-live remainder (the result reports the adjusted span), a fully compressed span is reported as already compressed, and invented/other-session seqs fail with guidance.
-- decompress: recover a compressed block's original content, read-only. decompress({ blockId }).
-- search_context: find information inside compressed blocks BEFORE decompressing. search_context({ query }).
-- acp_status: current context usage and the live compressible-range list. Run it right before compressing — the only seqs that never go stale are the ones you just read.
-
-Tiered compression: each compressed block appears on the surface as one summary node. Compressing that node again DISTILLS the block (tier 2): the parent summary folds into your new summary and the original messages are freed. Distilling a tier-2 block yields tier 3. Distill when a summary itself is consumed — decompress on the tier-2 block recovers the full originals.
-
-When you write a summary, it becomes the ONLY record of that range: keep file paths, signatures, exact values, decisions, and error strings verbatim so a later reader (or you, after decompress) can continue without the original. Never reuse historical seqs — the surface moves as messages land and compress; verify with acp_status.`
-
-test('M4/prompts 1: default system prompt renders byte-identical to the pre-change literal', () => {
-  assert.equal(renderSystemPrompt(resolvePrompts()), SYSTEM_PROMPT_SNAPSHOT)
+test('M4/prompts 1: default system prompt contains key sections in correct order', () => {
+  const rendered = renderSystemPrompt(resolvePrompts())
+  // Head
+  assert.ok(rendered.startsWith(SYSTEM_PROMPT_HEAD), 'system prompt starts with the new efficiency-notification framing')
+  // Philosophy
+  assert.ok(rendered.includes('Compression Philosophy:\n- All compression serves the primary task'), 'philosophy section present')
+  // WHEN TO / WHEN NOT
+  assert.ok(rendered.includes('WHEN TO COMPRESS:'), 'WHEN TO COMPRESS section present')
+  assert.ok(rendered.includes('WHEN NOT TO COMPRESS:'), 'WHEN NOT TO COMPRESS section present')
+  assert.ok(rendered.includes('A task phase has ended'), 'WHEN TO bullet present')
+  assert.ok(rendered.includes('Protected tool outputs'), 'WHEN NOT bullet present')
+  // HOW_TO_COMPRESS_RULES
+  assert.ok(rendered.includes('HOW TO COMPRESS'), 'HOW_TO_COMPRESS_RULES section present')
+  assert.ok(rendered.includes('KEEP VERBATIM'), 'KEEP VERBATIM section present')
+  assert.ok(rendered.includes('Write dense, scannable bullets'), 'formatting guidance present')
+  // Tool descriptions (DSH-specific: seq-based)
+  assert.ok(rendered.includes('Compression tools (refs are SURFACE SEQS, not ids):'), 'tool section present')
+  assert.ok(rendered.includes('compress: replace one or more seq ranges'), 'compress tool description present')
+  assert.ok(rendered.includes('Tiered compression:'), 'tiered compression section present')
+  // Tier rules
+  assert.ok(rendered.includes('TIER 2 COMPRESSION — DISTILLATION'), 'TIER2_DISTILL_RULES present')
+  assert.ok(rendered.includes('TIER 3 COMPRESSION — ULTRA-CONDENSATION'), 'TIER3_CONDENSE_RULES present')
+  assert.ok(rendered.includes('When you write a summary, it becomes the ONLY record'), 'summary writing rules present')
+  // No "suggestion, not an order" language
+  assert.ok(!rendered.includes('suggestion, not an order'), 'no "suggestion, not an order" language')
+  assert.ok(!rendered.includes('Nothing forces you'), 'no "Nothing forces you" language')
 })
 
-test('M4/prompts 2: default normal nudge snapshot — zero-range session, trailing newline is part of the bytes', () => {
+test('M4/prompts 2: default normal nudge — efficiency note + HOW_TO_COMPRESS_RULES + tip', () => {
   const text = buildNudgeText(fakeDecision(7, false), false, buildTextSession(4))
-  assert.equal(
-    text,
-    'Context usage is at 7%. This is a suggestion, not a requirement — you decide whether and when to compress.\n\n'
-      + 'Compress by need, not by percentage: replace only ranges you have genuinely consumed, with dense self-contained summaries.\n',
-  )
+  // Frame: efficiency note with philosophy embedded
+  assert.ok(text.startsWith('Context usage is at 7%. This is an efficiency nudge to compress early and keep context lean — not an overflow warning.'), 'frame starts with efficiency note')
+  assert.ok(text.includes('Compression Philosophy:\n- All compression serves the primary task'), 'philosophy embedded in frame')
+  // No "suggestion, not a requirement"
+  assert.ok(!text.includes('suggestion, not a requirement'), 'no "suggestion, not a requirement"')
+  // HOW_TO_COMPRESS_RULES as guidance
+  assert.ok(text.includes('HOW TO COMPRESS'), 'HOW_TO_COMPRESS_RULES present')
+  assert.ok(text.includes('KEEP VERBATIM'), 'KEEP VERBATIM section present')
+  // Tip at end
+  assert.ok(text.endsWith('💡 Compress all ranges in one call (pass multiple content entries: `content: [{...}, {...}]`).'), 'tip at end')
 })
 
-test('M4/prompts 3: default emergency nudge snapshot — ⚠️ frame, trailing newline', () => {
+test('M4/prompts 3: default emergency nudge — ⚠️ frame + HOW_TO_COMPRESS_RULES + tip', () => {
   const text = buildNudgeText(fakeDecision(96, true), true, buildTextSession(4))
-  assert.equal(
-    text,
-    '⚠️ Context usage is at 96% of the window — nearly full. Consider compressing consumed ranges soon so working context stays available; the choice and timing are yours.\n\n'
-      + 'Compress by need, not by percentage: replace only ranges you have genuinely consumed, with dense self-contained summaries.\n',
-  )
+  // Frame: emergency style with philosophy embedded
+  assert.ok(text.startsWith('⚠️ Context limit reached — compress now. Prioritize consumed tool outputs.'), 'emergency frame starts with compress now')
+  assert.ok(text.includes('Compression Philosophy:\n- All compression serves the primary task'), 'philosophy embedded in emergency frame')
+  // No "choice and timing are yours"
+  assert.ok(!text.includes('choice and timing are yours'), 'no "choice and timing are yours"')
+  // HOW_TO_COMPRESS_RULES
+  assert.ok(text.includes('HOW TO COMPRESS'), 'HOW_TO_COMPRESS_RULES present in emergency')
+  assert.ok(text.includes('KEEP VERBATIM'), 'KEEP VERBATIM present in emergency')
+  // Tip at end
+  assert.ok(text.endsWith('💡 Compress all ranges in one call (pass multiple content entries: `content: [{...}, {...}]`).'), 'tip at end in emergency')
 })
 
 test('M4/prompts 4: range table snapshot (with ranges) and zero-range early return', () => {
@@ -169,13 +187,21 @@ test('M4/prompts 9: renderTemplate throws on a missing value for a known placeho
   )
 })
 
-test('M4/prompts 10: empty guidance removes the line cleanly (frame + newline + table)', () => {
+test('M4/prompts 10: empty guidance removes the line cleanly (frame + newline + table + tip)', () => {
   const session = buildTextSession(12)
-  const prompts = resolvePrompts({ nudge: { guidance: '' } })
-  const frame = 'Context usage is at 7%. This is a suggestion, not a requirement — you decide whether and when to compress.'
+  const prompts = resolvePrompts({
+    nudge: {
+      guidance: '',
+      breakdown: '',
+      growth: '',
+      tip: '',
+    },
+  })
+  const frame = 'Context usage is at 7%. This is an efficiency nudge to compress early and keep context lean — not an overflow warning. A separate, stronger alert will appear if the context is actually full.\n\nCompression Philosophy:\n- All compression serves the primary task, but be frugal.\n- Context capacity is precious. Save context by compressing consumed outputs, not by avoiding tools.\n- Compress by need, not by percentage.\n- Work from summaries, not raw tool outputs. All listed ranges (user prompts, tool outputs, code, logs, exploration, intermediate steps) should be compressed to summary format — the ONLY exceptions are protected content, content the current step is actively using, or critical content you cannot reconstruct.'
   const text = buildNudgeText(fakeDecision(7, false), false, session, prompts)
   assert.equal(text, `${frame}\n${rangeTable(session)}`)
-  assert.ok(!text.includes('Compress by need'))
+  assert.ok(!text.includes('HOW TO COMPRESS'))
+  assert.ok(!text.includes('Compress all ranges'))
 })
 
 test('M4/prompts 11: tier line renders (0 tokens) when pending is missing (B2 fallback)', () => {
@@ -226,10 +252,13 @@ test('M4/prompts 12: buildNudge forwards env.prompts into the injected message (
 test('M4/prompts 13: Chinese override smoke (i18n scenario)', () => {
   const prompts = resolvePrompts({
     nudge: {
-      normal: '上下文使用率 {pct}%。这是建议,不是要求 —— 是否压缩、何时压缩,由你决定。',
-      emergency: '⚠️ 上下文使用率已达窗口的 {pct}% —— 几乎满了。',
-      guidance: '按需压缩,而不是按百分比:只替换你真正消费过的范围。',
+      normal: '上下文使用率 {pct}%。这是效率提示，不是溢出警告。',
+      emergency: '⚠️ 上下文已达上限，立即压缩。',
+      guidance: '压缩规则：保持路径、签名、错误原文。',
       tier: '第 {tier} 层:{count} 个第 {prevTier} 层块可蒸馏({tokens} tokens)。',
+      breakdown: '上下文分解：{system}K 系统 | {tool}K 工具 | {summaries}K 摘要 | {code}K 代码 | {text}K 文本',
+      growth: '+{growth}K 自上次提示',
+      tip: '💡 一次调用压缩多个范围。',
     },
     rangeTable: {
       header: '表面:{surface}',
@@ -237,15 +266,16 @@ test('M4/prompts 13: Chinese override smoke (i18n scenario)', () => {
       line: '  - seq {start}..{end} — {count} 条消息,约 {tokens} tokens',
       footer: '用 compress 压缩;批量条目各成一个块。',
     },
-    systemPrompt: '主动上下文剪枝 —— 模型驱动。\n{philosophy}\n压缩工具:compress/decompress/search_context/acp_status。',
+    systemPrompt: '主动上下文剪枝 —— 模型驱动。\n{philosophy}\n{howToCompressRules}\n压缩工具:compress/decompress/search_context/acp_status。',
   })
   const session = buildTextSession(12)
   const text = buildNudgeText(fakeDecision(7, false), false, session, prompts)
   assert.ok(text.includes('上下文使用率 7%'))
   assert.ok(text.includes('表面:12 nodes, seqs 1..12'))
   assert.ok(text.includes('可压缩范围(仅供参考):'))
+  assert.ok(text.includes('💡 一次调用压缩多个范围'))
   const emerg = buildNudgeText(fakeDecision(96, true), true, session, prompts)
-  assert.ok(emerg.includes('已达窗口的 96%'))
+  assert.ok(emerg.includes('上下文已达上限'))
   const sys = renderSystemPrompt(prompts)
   assert.ok(sys.includes('主动上下文剪枝'))
   assert.ok(sys.includes('Compression Philosophy:'))

--- a/tests/prompts.test.ts
+++ b/tests/prompts.test.ts
@@ -100,8 +100,9 @@ test('M4/prompts 1: default system prompt contains key sections in correct order
 
 test('M4/prompts 2: default normal nudge — efficiency note + HOW_TO_COMPRESS_RULES + tip', () => {
   const text = buildNudgeText(fakeDecision(7, false), false, buildTextSession(4))
-  // Frame: efficiency note with philosophy embedded
-  assert.ok(text.startsWith('Context usage is at 7%. This is an efficiency nudge to compress early and keep context lean — not an overflow warning.'), 'frame starts with efficiency note')
+  // Frame: kernel EFFICIENCY_NOTE verbatim (no "Context usage is at X%" statement)
+  assert.ok(text.startsWith('This is an efficiency nudge to compress early and keep context lean — not an overflow warning.'), 'frame starts with efficiency note')
+  assert.ok(!text.includes('Context usage is at'), 'no "Context usage is at" usage statement in the nudge')
   assert.ok(text.includes('Compression Philosophy:\n- All compression serves the primary task'), 'philosophy embedded in frame')
   // No "suggestion, not a requirement"
   assert.ok(!text.includes('suggestion, not a requirement'), 'no "suggestion, not a requirement"')
@@ -197,7 +198,7 @@ test('M4/prompts 10: empty guidance removes the line cleanly (frame + newline + 
       tip: '',
     },
   })
-  const frame = 'Context usage is at 7%. This is an efficiency nudge to compress early and keep context lean — not an overflow warning. A separate, stronger alert will appear if the context is actually full.\n\nCompression Philosophy:\n- All compression serves the primary task, but be frugal.\n- Context capacity is precious. Save context by compressing consumed outputs, not by avoiding tools.\n- Compress by need, not by percentage.\n- Work from summaries, not raw tool outputs. All listed ranges (user prompts, tool outputs, code, logs, exploration, intermediate steps) should be compressed to summary format — the ONLY exceptions are protected content, content the current step is actively using, or critical content you cannot reconstruct.'
+  const frame = 'This is an efficiency nudge to compress early and keep context lean — not an overflow warning. A separate, stronger alert will appear if the context is actually full.\n\nCompression Philosophy:\n- All compression serves the primary task, but be frugal.\n- Context capacity is precious. Save context by compressing consumed outputs, not by avoiding tools.\n- Compress by need, not by percentage.\n- Work from summaries, not raw tool outputs. All listed ranges (user prompts, tool outputs, code, logs, exploration, intermediate steps) should be compressed to summary format — the ONLY exceptions are protected content, content the current step is actively using, or critical content you cannot reconstruct.'
   const text = buildNudgeText(fakeDecision(7, false), false, session, prompts)
   assert.equal(text, `${frame}\n${rangeTable(session)}`)
   assert.ok(!text.includes('HOW TO COMPRESS'))

--- a/tests/prompts.test.ts
+++ b/tests/prompts.test.ts
@@ -113,7 +113,27 @@ test('M4/prompts 2: default normal nudge — efficiency note + HOW_TO_COMPRESS_R
   assert.ok(text.endsWith('💡 Compress all ranges in one call (pass multiple content entries: `content: [{...}, {...}]`).'), 'tip at end')
 })
 
-test('M4/prompts 3: default emergency nudge — ⚠️ frame + HOW_TO_COMPRESS_RULES + tip', () => {
+test('M4/prompts 2b: default nudge renders through the kernel renderNudgeText path (seq table replaces ref table)', () => {
+  // With a compressible range present, the DEFAULT nudge must come from the
+  // kernel's renderNudgeText (EFFICIENCY_NOTE / breakdown / HOW_TO_COMPRESS_RULES /
+  // tip verbatim) with ONLY the ref-ID rangesStr replaced by our seq table.
+  const session = buildTextSession(12)
+  const text = buildNudgeText(fakeDecision(50, false), false, session)
+  // Kernel frame + philosophy + rules + tip, all verbatim from acp-kernel
+  assert.ok(text.startsWith('This is an efficiency nudge to compress early and keep context lean — not an overflow warning.'), 'kernel EFFICIENCY_NOTE frame')
+  assert.ok(text.includes('HOW TO COMPRESS'), 'kernel HOW_TO_COMPRESS_RULES')
+  assert.ok(text.endsWith('💡 Compress all ranges in one call (pass multiple content entries: `content: [{...}, {...}]`).'), 'kernel batch tip at end')
+  // Ref-ID rangesStr replaced by the surface-seq table
+  assert.ok(!text.includes('oldest first'), 'kernel ref rangesStr header gone')
+  assert.ok(!text.includes('m00150'), 'kernel ref range sample gone')
+  assert.ok(text.includes('seq 1..7'), 'surface-seq range table injected')
+  assert.ok(text.includes('Surface: 12 nodes, seqs 1..12'), 'surface summary present')
+  // No usage statement; the only mNNNNN tokens are inside kernel's own
+  // HOW_TO_COMPRESS_RULES example text (m00420 key anchors), not a leak.
+  assert.ok(!text.includes('Context usage is at'), 'no usage statement')
+})
+
+test('M4/prompts 3: default emergency nudge — ⚠️ frame + HOW_TO_COMPRESS_RULES + seq example', () => {
   const text = buildNudgeText(fakeDecision(96, true), true, buildTextSession(4))
   // Frame: emergency style with philosophy embedded
   assert.ok(text.startsWith('⚠️ Context limit reached — compress now. Prioritize consumed tool outputs.'), 'emergency frame starts with compress now')
@@ -123,8 +143,10 @@ test('M4/prompts 3: default emergency nudge — ⚠️ frame + HOW_TO_COMPRESS_R
   // HOW_TO_COMPRESS_RULES
   assert.ok(text.includes('HOW TO COMPRESS'), 'HOW_TO_COMPRESS_RULES present in emergency')
   assert.ok(text.includes('KEEP VERBATIM'), 'KEEP VERBATIM present in emergency')
-  // Tip at end
-  assert.ok(text.endsWith('💡 Compress all ranges in one call (pass multiple content entries: `content: [{...}, {...}]`).'), 'tip at end in emergency')
+  // Ref-ID example replaced with the seq example (kernel emergency has no 💡 tip)
+  assert.ok(!text.includes('startId'), 'no ref-ID startId in the emergency example')
+  assert.ok(text.includes('compress({ content: [{ startSeq, endSeq, summary }] })'), 'seq example replaces the ref-ID example')
+  assert.ok(!text.includes('💡 Compress all ranges'), 'kernel emergency nudge has no batch tip (kernel parity)')
 })
 
 test('M4/prompts 4: range table snapshot (with ranges) and zero-range early return', () => {
@@ -210,7 +232,7 @@ test('M4/prompts 11: tier line renders (0 tokens) when pending is missing (B2 fa
     shouldInject: true,
     reason: 'tier-2 distillation recommended',
     compressibleRanges: [],
-    tierTargetBlocks: [{ blockId: 'b1' } as never],
+    tierTargetBlocks: [{ blockId: 'b1', tier: 1, effectiveMessageIds: ['m1'], compressedTokens: 4750, summary: 's', active: true, directMessageIds: [], directBlockIds: [], createdAt: 1, survivedCount: 0, generation: 'young' }],
     contextUsage: 0.9,
     tier: 2,
     // pendingT2 deliberately absent at runtime: NudgeBreakdown requires it

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -236,6 +236,40 @@ test('M3: tools refuse to run without an agent context', async () => {
   )
 })
 
+test('M3: compress tolerates the wrapped-arguments form ({ arguments: "..." } double-nesting)', async () => {
+  // Some models emit `{ "arguments": "{\"content\": [...]}" }` (double-nested)
+  // instead of the unwrapped `{ "content": [...] }`. The old DSH validator
+  // surfaced this as `"arguments" must be an object` and sent the model into a
+  // retry loop; the schema now accepts `arguments` as an optional JSON node
+  // and handleCompress unwraps it before range resolution.
+  const env = makeEnv()
+  const session = buildTextSession(12)
+  const compress = toolOf(env, 'compress')
+  const wrapped = {
+    arguments: JSON.stringify({
+      content: [{
+        startSeq: 1,
+        endSeq: 3,
+        summary: 'Authentication: JWT access tokens with 15 minute expiry, refresh tokens in Redis with 30 day TTL, login flow in src/auth/login.ts with sliding-window rate limiting at 10 requests per minute, bcrypt at cost 12.',
+      }],
+    }),
+  }
+  const result = await compress.execute(wrapped as never, fakeExec(session))
+  const text = (result as { text: string }).text
+  assert.match(text, /Compressed 1 block/, 'the wrapped form unwraps and compresses the same content')
+  const ledger = rebuildBlockLedger(session.events)
+  assert.equal(ledger.length, 1, 'the wrapped form lands the durable block')
+})
+
+test('M3: compress reports a clear error when neither form carries content', async () => {
+  const env = makeEnv()
+  const session = buildTextSession(4)
+  const compress = toolOf(env, 'compress')
+  const result = await compress.execute({ arguments: 'not even json' } as never, fakeExec(session))
+  assert.match((result as { text: string }).text, /missing content/, 'no content in either form yields the guidance message')
+  assert.equal(rebuildBlockLedger(session.events).length, 0, 'no block lands without content')
+})
+
 /** A session whose second node is a multi-tool-call assistant message. */
 function buildMultiCallSession(): Session {
   const session = Session.create('multi')


### PR DESCRIPTION
## Summary

Aligns the default nudge and system-prompt copy with **acp-kernel / billion-context-pi** so the model treats compression as an efficiency practice rather than an optional extra. Root motivation: the previous "suggestion, not a requirement — you decide" opener gave the model a standing reason to ignore the nudge.

## Changes

**Nudge frames** (`src/prompts.ts` `DEFAULT_PROMPTS.nudge`)
- `normal`: `"suggestion, not a requirement"` → `"efficiency nudge to compress early and keep context lean — not an overflow warning"` + embedded `{philosophy}` (kernel `COMPRESS_PHILOSOPHY`)
- `emergency`: `"Consider compressing... the choice and timing are yours"` → `"⚠️ Context limit reached — compress now. Prioritize consumed tool outputs."` + embedded `{philosophy}`
- `guidance` default: one-line "Compress by need" → kernel `HOW_TO_COMPRESS_RULES` (KEEP/DROP/PRIORITY/format)
- New configurable slots (kernel-parity): `breakdown` (context breakdown, K-formatted), `growth` ("+N since last nudge"), `tip` ("💡 Compress all ranges in one call")

**Assembly** (`src/nudge.ts` `buildNudgeText`) — aligned with kernel `renderNudgeText` order:
`frame` → `breakdown` → `growth` → `guidance` (HOW_TO_COMPRESS_RULES) → tier line (+ kernel `TIER2_DISTILL_RULES`/`TIER3_CONDENSE_RULES` for tier nudges, **skipping the range table**) → range table (non-tier only) → `tip`

**System prompt** (`src/prompts.ts` `systemPromptTemplate` + `src/system-prompt.ts`)
- Efficiency-notification framing (removed "Nothing forces you")
- `WHEN TO COMPRESS` / `WHEN NOT TO COMPRESS` scenario lists (pi parity)
- New placeholders: `{howToCompressRules}` / `{tier2DistillRules}` / `{tier3CondenseRules}` — `renderSystemPrompt` now injects 4 kernel variables

**Tests** (`tests/prompts.test.ts`) — snapshots re-anchored on the new default copy: key-section assertions for the system prompt (byte-exact whole-string snapshot replaced, since kernel rule text makes it long-lived), efficiency-note frame assertions for normal/emergency nudges, empty-guidance case extended to also empty breakdown/growth/tip.

**Docs**: `docs/configurable-prompts-design.md` updated to v5 (new slots, assembly order, defaults, test plan); README.md / README.en.md prompts section + nudge description updated; AGENTS.md design-decision #3 reworded.

## Verification

- `npm run typecheck` ✅
- `npm test` — 77/77 pass ✅
- `npm run build` ✅
- Live DSH session: new normal nudge observed with efficiency-note frame, context breakdown, HOW_TO_COMPRESS_RULES, seq range table, and batch tip (previously the old "suggestion" copy persisted)

## Notes

- Config-slot structure stays backward-compatible: existing `prompts.nudge.normal` overrides still work; only **default** copy changed (intentional, K1–K4).
- Live-verified in the DSH web profile after a rebuild + restart: new copy reached the injected nudge on both the old session (post-restart) and a fresh ACP-mode session.