### PR TITLE
release v0.2.0

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -3,7 +3,7 @@
 [English](./README.en.md) | [中文](./README.md)
 
 > **⚠️ Beta notice — not for production use**
-> This project (**v0.1.9**) is a work-in-progress beta. The [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) itself is also in **public beta**. **Do not use either in engineering / production environments** — expect breaking changes and rough edges.
+> This project (**v0.2.0**) is a work-in-progress beta. The [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) itself is also in **public beta**. **Do not use either in engineering / production environments** — expect breaking changes and rough edges.
 
 <p align="center">
 <strong>Built with gratitude on top of these projects</strong> — please give them a ⭐:
@@ -55,6 +55,18 @@ This is the DeepSeek Harness port of [billion-context-pi](https://github.com/ran
 ```bash
 npm install billion-context-dsh
 ```
+
+> 💡 **One-command install via `dsh plugin` (bundle, v0.2.0+)**. The package declares a `dsh.bundle`
+> manifest, so DSH's plugin command installs it into the profile and applies the patch
+> automatically (equivalent to the composition row below):
+
+```bash
+dsh plugin --profile web add billion-context-dsh
+```
+
+Restart `dsh` afterwards (bundle layers are composed at startup). For custom `config`
+(such as `modelContextLimit` / `prompts`), keep the hand-written composition row — the
+bundle patch ([cordis.patch.yml](cordis.patch.yml)) only inserts the default row without `config`.
 
 That's it. Then add a composition row where a compaction backend is expected — two scopes, pick by how wide you want it:
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [中文](./README.md) | [English](./README.en.md)
 
 > **⚠️ 测试版声明——请勿用于生产环境**
-> 本项目（**v0.1.9**）仍处于开发中的测试版。[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 本身也处于**公开测试版**阶段。**请勿将两者用于工程化 / 生产环境**——预期会有破坏性变更与粗糙之处。
+> 本项目（**v0.2.0**）仍处于开发中的测试版。[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 本身也处于**公开测试版**阶段。**请勿将两者用于工程化 / 生产环境**——预期会有破坏性变更与粗糙之处。
 
 <p align="center">
 <strong>衷心感谢以下项目——请给它们一个 ⭐：</strong>
@@ -58,6 +58,17 @@
 ```bash
 npm install billion-context-dsh
 ```
+
+> 💡 **v0.2.0 起支持 `dsh plugin` 一键安装（bundle）**。包已声明 `dsh.bundle`
+> manifest，DSH 的插件命令会把它装进 profile 并自动应用补丁（等价于下面的组合行）：
+
+```bash
+dsh plugin --profile web add billion-context-dsh
+```
+
+装完重启 `dsh`（bundle 层在启动时组合）。需要自定义 `config`（如
+`modelContextLimit` / `prompts`）时仍建议手写组合行——bundle 补丁
+（[cordis.patch.yml](cordis.patch.yml)）只插入无 `config` 的默认行。
 
 就这样。然后在需要压缩后端的位置加组合配置——两种范围，按需选择：
 

--- a/cordis.patch.yml
+++ b/cordis.patch.yml
@@ -1,0 +1,11 @@
+# dsh bundle patch: inserts the ACP compaction backend into a profile's layer stack.
+#
+# This is what makes the package installable via `dsh plugin --profile web add
+# billion-context-dsh` (declared in package.json as `dsh.bundle.patch`). The row
+# below is exactly the manual composition row documented in docs/INSTALL.md (§2a),
+# minus config: omitting `modelContextLimit` means auto-detection (fallback 128000),
+# and the built-in prompt copy (config.prompts) is used. Users who want custom
+# config can still write the row by hand in their profile patch.
+- insert:
+    - id: compaction-acp
+      name: 'billion-context-dsh'

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -22,6 +22,21 @@ mkdir -p ~/.dsh/profiles/web/node_modules
 npm install --prefix ~/.dsh/profiles/web ./billion-context-dsh-0.0.0.tgz
 ```
 
+### 方式 C：bundle 安装（v0.2.0+，`dsh plugin` 一键装）
+
+包已声明 `dsh.bundle` manifest（`package.json` 的 `dsh.bundle.patch` → 仓库根的
+[../cordis.patch.yml](../cordis.patch.yml)），可用 DSH 的插件机制安装，patch 自动把
+ACP 组合行插入当前 profile 的层栈：
+
+```bash
+dsh plugin --profile web add billion-context-dsh
+```
+
+装完重启 `dsh`（bundle 层在启动时组合）。该方式等效于下面 2a 的手写组合行
+（id `compaction-acp`、name `billion-context-dsh`）；bundle 的默认 patch 不带
+`config`（`modelContextLimit` 省略 = 自动探测、提示词用内置文案），需要自定义
+`config` 时仍建议手写组合行。
+
 ## 2. 组合行
 
 两种挂法，按你想要生效的范围选。

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 [English](./README.md) · [简体中文](../README.md) · [项目主页](https://github.com/Tyan66666/billion-context-dsh)
 
-> **⚠️ Beta** — this project (v0.1.9) and the [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) are both in **public beta**: do not use in engineering / production environments.
+> **⚠️ Beta** — this project (v0.2.0) and the [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) are both in **public beta**: do not use in engineering / production environments.
 
 Model-driven context management (Active Context Pruning / ACP) for the DeepSeek Harness, ported from [billion-context-pi](https://github.com/ranxianglei/billion-context-pi). The compression core ([acp-kernel](https://github.com/ranxianglei/acp-kernel)) is reused verbatim.
 
@@ -33,6 +33,7 @@ src/
 
 ## 📦 Releases
 
+- [v0.2.0](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.2.0) — (feat) ship a `dsh.bundle` manifest: the package is now installable with `dsh plugin --profile web add billion-context-dsh` (the patch auto-inserts the composition row), which also unlocks listing in the awesome-dsh-plugin registry and the dsh-market plugin store; (chore) add npm keywords for search discoverability; docs: bundle install method in README (zh/en) and INSTALL.md 方式 C; 77 tests pass (no regression)
 - [v0.1.9](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.9) — (chore) bump acp-kernel 0.0.23 → 0.0.24 (inline-dependency upgrade); docs: update acp-kernel version reference in AGENTS.md; 62 tests pass (no regression)
 - [v0.1.8](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.8) — (fix) system prompt section cold-start retry: the ACP guidance section is now registered even when the `systemPrompt` service activates after the engine — matches the same retry pattern used by tools and commands; (fix) nudge context pressure now reads from `sessionProjections.contextPressure.projectedTokens` (matches the UI context-occupancy display; includes fixed overhead) instead of `tokenMeter.measure(session).surfaceTokens`; docs: INSTALL.md 2a notes that disabling compaction-basic is redundant on dsh 0.1.0-rc.6+; + 3 regression tests (62 tests)
 - [v0.1.7](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.7) — (fix) compress no longer fails with *seq not in the current surface* when the model reuses stale refs (old nudge tables / earlier compress results): shadowed edges are remapped to the still-live content of the requested span, a fully shadowed span is reported as *already compressed* with the covering block ids, block checkpoint nodes are never folded on a stale reference (distillation stays explicit), and invented/other-session seqs still fail with acp_status guidance; guidance updated in the system prompt, nudge range table and compress tool description, + 6 regression tests (60 tests)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # billion-context-dsh
 
-> **⚠️ Beta notice** — this project (v0.1.9) and the [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) are both in **public beta**: do not use in engineering / production environments.
+> **⚠️ Beta notice** — this project (v0.2.0) and the [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) are both in **public beta**: do not use in engineering / production environments.
 
 **Model-driven context management (Active Context Pruning / ACP) for the DeepSeek Harness.** The model decides *when* and *what* to compress — not a hard limit. Ported from [billion-context-pi](https://github.com/ranxianglei/billion-context-pi) (by [ranxianglei](https://github.com/ranxianglei), MIT); the compression core [acp-kernel](https://github.com/ranxianglei/acp-kernel) is reused verbatim.
 
@@ -19,6 +19,6 @@
 ## 🔗 Quick links
 
 - **Repository**: [github.com/Tyan66666/billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh)
-- **npm**: [billion-context-dsh@0.1.9](https://www.npmjs.com/package/billion-context-dsh)
-- **Releases**: [v0.1.9](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.9) · [v0.1.8](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.8) · [v0.1.7](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.7) · [v0.1.6](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.6) · [v0.1.5](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.5) · [v0.1.4](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.4) · [v0.1.3](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.3) · [v0.1.2](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.2) · [v0.1.1](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.1) · [v0.1.0](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.0)
+- **npm**: [billion-context-dsh@0.2.0](https://www.npmjs.com/package/billion-context-dsh)
+- **Releases**: [v0.2.0](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.2.0) · [v0.1.9](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.9) · [v0.1.8](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.8) · [v0.1.7](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.7) · [v0.1.6](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.6) · [v0.1.5](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.5) · [v0.1.4](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.4) · [v0.1.3](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.3) · [v0.1.2](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.2) · [v0.1.1](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.1) · [v0.1.0](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.0)
 - **Upstream**: [billion-context-pi](https://github.com/ranxianglei/billion-context-pi) · [acp-kernel](https://github.com/ranxianglei/acp-kernel) · [opencode-acp](https://github.com/ranxianglei/opencode-acp) · [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "billion-context-dsh",
-	"version": "0.1.9",
+	"version": "0.2.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-dsh",
-			"version": "0.1.9",
+			"version": "0.2.0",
 			"license": "MIT",
 			"dependencies": {
 				"acp-kernel": "0.0.24"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,19 @@
 {
 	"name": "billion-context-dsh",
-	"version": "0.1.9",
+	"version": "0.2.0",
 	"description": "Active Context Pruning (ACP) for the DeepSeek Harness — model-driven context management as a CompactionEngine backend.",
+	"keywords": [
+		"deepseek",
+		"harness",
+		"dsh",
+		"dsh-plugin",
+		"acp",
+		"context-management",
+		"context-compression",
+		"llm",
+		"agent",
+		"compaction"
+	],
 	"type": "module",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
@@ -13,11 +25,17 @@
 	},
 	"files": [
 		"dist",
+		"cordis.patch.yml",
 		"README.md",
 		"README.en.md",
 		"LICENSE"
 	],
 	"sideEffects": false,
+	"dsh": {
+		"bundle": {
+			"patch": "./cordis.patch.yml"
+		}
+	},
 	"license": "MIT",
 	"engines": {
 		"node": ">=20"


### PR DESCRIPTION
## release v0.2.0

**(feat) ship a `dsh.bundle` manifest — billion-context-dsh is now installable with `dsh plugin --profile web add billion-context-dsh`**, which also unlocks listing in the [awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) registry and the in-app [dsh-market](https://github.com/dsh-market/dsh-market) plugin store (their catalog syncs from the awesome-dsh-plugin website).

### Changes
- `package.json`: add `dsh.bundle.patch → ./cordis.patch.yml` manifest; add npm `keywords` (deepseek, harness, dsh, dsh-plugin, acp, context-management, …); include `cordis.patch.yml` in the published `files`.
- New `cordis.patch.yml`: inserts the `compaction-acp` composition row — identical to the documented manual row, no `config` (auto-detected context window + built-in prompt copy).
- Docs: README (zh/en) install section gains the `dsh plugin` one-liner; `docs/INSTALL.md` gains 方式 C (bundle install); version refs bumped to v0.2.0 in README.md / README.en.md / docs/README.md / docs/index.md.

### Verification
- `npm run typecheck` ✅
- `npm test` — 77 tests pass, 0 fail ✅
- `npm run build` ✅ (dist/index.js 56.18 KB)
- `npm pack --dry-run` — tarball contains `cordis.patch.yml` + the `dsh.bundle` manifest ✅
- Published: `billion-context-dsh@0.2.0` on npm ✅

### Follow-up (separate PR, human merge)
- PR to awesome-dsh-plugin listing the package under Memory (auto-syncs to dsh-market within a day).