### PR TITLE
release v0.2.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,7 @@ The PR title is enforced by CI (`.github/workflows/pr-lint.yml` → `scripts/che
    - ref assignment / `compressibleRanges` — we deliberately self-compute the range table, so drift here is absorbed, but confirm
    - `CoreMessage` / `NudgeDecision` types — `messages.ts`, `nudge.ts`
 3. Bump the exact version in `package.json`, run `npm install` (refreshes lock), then `npm run typecheck && npm test && npm run build`.
-4. **The test suite is the safety net**: 77 tests cover the battle-hardened behaviors (CJK estimation, lone-tool expansion, surface range table, ledger backfill, ref-tag projection). Any kernel behavior change that breaks one of those turns red here — do NOT release on red.
+4. **The test suite is the safety net**: 80 tests cover the battle-hardened behaviors (CJK estimation, lone-tool expansion, surface range table, ledger backfill, ref-tag projection). Any kernel behavior change that breaks one of those turns red here — do NOT release on red.
 5. Optionally enable new kernel features deliberately (e.g. `createBpeTokenizer()` behind a config flag) — never adopt silently.
 6. Release per the workflow below (bump own version, publish, `gh release create`).
 

--- a/README.en.md
+++ b/README.en.md
@@ -3,7 +3,7 @@
 [English](./README.en.md) | [中文](./README.md)
 
 > **⚠️ Beta notice — not for production use**
-> This project (**v0.2.0**) is a work-in-progress beta. The [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) itself is also in **public beta**. **Do not use either in engineering / production environments** — expect breaking changes and rough edges.
+> This project (**v0.2.1**) is a work-in-progress beta. The [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) itself is also in **public beta**. **Do not use either in engineering / production environments** — expect breaking changes and rough edges.
 
 <p align="center">
 <strong>Built with gratitude on top of these projects</strong> — please give them a ⭐:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [中文](./README.md) | [English](./README.en.md)
 
 > **⚠️ 测试版声明——请勿用于生产环境**
-> 本项目（**v0.2.0**）仍处于开发中的测试版。[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 本身也处于**公开测试版**阶段。**请勿将两者用于工程化 / 生产环境**——预期会有破坏性变更与粗糙之处。
+> 本项目（**v0.2.1**）仍处于开发中的测试版。[DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) 本身也处于**公开测试版**阶段。**请勿将两者用于工程化 / 生产环境**——预期会有破坏性变更与粗糙之处。
 
 <p align="center">
 <strong>衷心感谢以下项目——请给它们一个 ⭐：</strong>

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -17,9 +17,9 @@ ln -s /Users/yintianan/GitHub/billion-context-dsh ~/.dsh/profiles/web/node_modul
 
 ```bash
 cd /Users/yintianan/GitHub/billion-context-dsh
-npm pack                        # 产出 billion-context-dsh-0.2.0.tgz
+npm pack                        # 产出 billion-context-dsh-0.2.1.tgz
 mkdir -p ~/.dsh/profiles/web/node_modules
-npm install --prefix ~/.dsh/profiles/web ./billion-context-dsh-0.2.0.tgz
+npm install --prefix ~/.dsh/profiles/web ./billion-context-dsh-0.2.1.tgz
 ```
 
 ### 方式 C：bundle 安装（v0.2.0+，`dsh plugin` 一键装）
@@ -146,7 +146,7 @@ cd /Users/yintianan/GitHub/billion-context-dsh
 npm run typecheck && npm test && npm run build
 ```
 
-77 个测试覆盖：seam 挂载、窗口探测、CJK 感知 token 估算、消息投影、压缩事务（事件序列 + surface 遮蔽）、日志重建账本、四工具端到端、nudge 注入/去重/紧急绕过、可配置提示词模板与校验。
+80 个测试覆盖：seam 挂载、窗口探测、CJK 感知 token 估算、消息投影、压缩事务（事件序列 + surface 遮蔽）、日志重建账本、四工具端到端、nudge 注入/去重/紧急绕过、可配置提示词模板与校验。
 
 ## 6. 回滚
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 [English](./README.md) · [简体中文](../README.md) · [项目主页](https://github.com/Tyan66666/billion-context-dsh)
 
-> **⚠️ Beta** — this project (v0.2.0) and the [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) are both in **public beta**: do not use in engineering / production environments.
+> **⚠️ Beta** — this project (v0.2.1) and the [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) are both in **public beta**: do not use in engineering / production environments.
 
 Model-driven context management (Active Context Pruning / ACP) for the DeepSeek Harness, ported from [billion-context-pi](https://github.com/ranxianglei/billion-context-pi). The compression core ([acp-kernel](https://github.com/ranxianglei/acp-kernel)) is reused verbatim.
 
@@ -34,6 +34,7 @@ src/
 
 ## 📦 Releases
 
+- [v0.2.1](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.2.1) — (feat) align nudge and system-prompt copy with acp-kernel/billion-context-pi (#14): default nudges now render through the kernel's `renderNudgeText` — efficiency-note frame ("not an overflow warning"), context breakdown, HOW_TO_COMPRESS_RULES, tier rules (TIER2/3), and batch tip — with only the ref-ID segments adapted to the surface-seq range table; the emergency tier says "compress now"; the system prompt gains WHEN TO COMPRESS / WHEN NOT TO COMPRESS lists and kernel rule placeholders; `config.prompts` overrides keep the template path (custom copy wins); + 3 regression tests (80 tests pass, no regression)
 - [v0.2.0](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.2.0) — (feat) ship a `dsh.bundle` manifest: the package is now installable with `dsh plugin --profile web add billion-context-dsh` (the patch auto-inserts the composition row), which also unlocks listing in the awesome-dsh-plugin registry and the dsh-market plugin store; (chore) add npm keywords for search discoverability; docs: bundle install method in README (zh/en) and INSTALL.md 方式 C; 77 tests pass (no regression)
 - [v0.1.9](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.9) — (feat) configurable per-stage prompts via `config.prompts` (nudge frames/range table/system prompt/tool descriptions as validated templates; fail-fast on unknown placeholders), (chore) bump acp-kernel 0.0.23 → 0.0.24 (inline-dependency upgrade), docs: update acp-kernel version reference in AGENTS.md; 77 tests pass (no regression)
 - [v0.1.8](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.8) — (fix) system prompt section cold-start retry: the ACP guidance section is now registered even when the `systemPrompt` service activates after the engine — matches the same retry pattern used by tools and commands; (fix) nudge context pressure now reads from `sessionProjections.contextPressure.projectedTokens` (matches the UI context-occupancy display; includes fixed overhead) instead of `tokenMeter.measure(session).surfaceTokens`; docs: INSTALL.md 2a notes that disabling compaction-basic is redundant on dsh 0.1.0-rc.6+; + 3 regression tests (62 tests)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # billion-context-dsh
 
-> **⚠️ Beta notice** — this project (v0.2.0) and the [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) are both in **public beta**: do not use in engineering / production environments.
+> **⚠️ Beta notice** — this project (v0.2.1) and the [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) are both in **public beta**: do not use in engineering / production environments.
 
 **Model-driven context management (Active Context Pruning / ACP) for the DeepSeek Harness.** The model decides *when* and *what* to compress — not a hard limit. Ported from [billion-context-pi](https://github.com/ranxianglei/billion-context-pi) (by [ranxianglei](https://github.com/ranxianglei), MIT); the compression core [acp-kernel](https://github.com/ranxianglei/acp-kernel) is reused verbatim.
 
@@ -19,6 +19,6 @@
 ## 🔗 Quick links
 
 - **Repository**: [github.com/Tyan66666/billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh)
-- **npm**: [billion-context-dsh@0.2.0](https://www.npmjs.com/package/billion-context-dsh)
-- **Releases**: [v0.2.0](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.2.0) · [v0.1.9](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.9) · [v0.1.8](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.8) · [v0.1.7](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.7) · [v0.1.6](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.6) · [v0.1.5](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.5) · [v0.1.4](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.4) · [v0.1.3](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.3) · [v0.1.2](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.2) · [v0.1.1](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.1) · [v0.1.0](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.0)
+- **npm**: [billion-context-dsh@0.2.1](https://www.npmjs.com/package/billion-context-dsh)
+- **Releases**: [v0.2.1](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.2.1) · [v0.2.0](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.2.0) · [v0.1.9](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.9) · [v0.1.8](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.8) · [v0.1.7](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.7) · [v0.1.6](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.6) · [v0.1.5](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.5) · [v0.1.4](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.4) · [v0.1.3](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.3) · [v0.1.2](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.2) · [v0.1.1](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.1) · [v0.1.0](https://github.com/Tyan66666/billion-context-dsh/releases/tag/v0.1.0)
 - **Upstream**: [billion-context-pi](https://github.com/ranxianglei/billion-context-pi) · [acp-kernel](https://github.com/ranxianglei/acp-kernel) · [opencode-acp](https://github.com/ranxianglei/opencode-acp) · [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "billion-context-dsh",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "billion-context-dsh",
-			"version": "0.2.0",
+			"version": "0.2.1",
 			"license": "MIT",
 			"dependencies": {
 				"acp-kernel": "0.0.24"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "billion-context-dsh",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"description": "Active Context Pruning (ACP) for the DeepSeek Harness — model-driven context management as a CompactionEngine backend.",
 	"keywords": [
 		"deepseek",


### PR DESCRIPTION
# release v0.2.1

Patch bump `0.2.0 → 0.2.1`. Content already on `main` since v0.2.0:

- `(feat)` align nudge and system-prompt copy with acp-kernel/billion-context-pi (#14) — default nudges render via kernel `renderNudgeText` (efficiency-note frame, context breakdown, HOW_TO_COMPRESS_RULES, tier rules, batch tip) with ref-ID segments adapted to the surface-seq range table; emergency tier says "compress now"; system prompt gains WHEN TO COMPRESS / WHEN NOT TO COMPRESS; `config.prompts` overrides keep the template path
- `docs:` sync stale doc numbers with actual state (#16)

This release commit:

- bumps `package.json` / `package-lock.json` to **0.2.1**
- refreshes `v0.2.1` references (Beta notice + release links) in `README.md`, `README.en.md`, `docs/README.md`, `docs/index.md`
- fixes stale test-count claims (77 → 80, +3 regression tests from #14) in `AGENTS.md` and `docs/INSTALL.md`

## Pre-flight (all pass)

- `npm run typecheck` ✅
- `npm test` — 80/80 pass ✅
- `npm run build` ✅

## After merge

`npm publish` + `gh release create v0.2.1` with notes listing #14's changes and live verification data.
