### PR TITLE
docs: rewrite Why section — drop seq-ref bullet, add long-task and lean-context advantages

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -41,10 +41,11 @@ When conversations get long, the model runs out of context. Most tools hard-trun
 
 Unlike DSH's built-in auto-compaction (which replaces a range with an automatically generated summary), billion-context-dsh:
 
-- **Model-driven** — the model writes the summary itself; there is no second LLM summarization call (the ACP cost win)
+- **Model-driven** — the model writes the summary itself; there is no second LLM summarization call
 - **Advisory, never imperative** — automatic policy only *nudges*; the model decides whether and when to compress
 - **Durable & recoverable** — a compressed range becomes a checkpoint node, the originals stay in the append-only session log; `decompress` restores them, `search_context` finds information inside blocks
-- **Seq-based refs** — no message tags; surface seqs are carried by the nudge's range table, with auto-balanced range edges and `#callId` tolerance
+- **Long tasks hold steady** — every step builds on the results before it; key conclusions stay usable and compound, so very long tasks actually finish
+- **Context stays lean** — every request rides on a small, distilled slice of context with only the key information; no bulk compression of large ranges, so details don't decay with it — and tokens stay low
 
 This is the DeepSeek Harness port of [billion-context-pi](https://github.com/ranxianglei/billion-context-pi) (the Pi coding-agent adapter): the compression core ([acp-kernel](https://github.com/ranxianglei/acp-kernel)) is reused verbatim, and the adapter layer was rewritten against DSH's durable-surface model — see [docs](https://github.com/Tyan66666/billion-context-dsh/tree/main/docs) for the verified mapping.
 

--- a/README.md
+++ b/README.md
@@ -41,10 +41,11 @@
 
 与 DSH 内置的自动压缩（用自动生成的摘要替换一段范围）不同，billion-context-dsh：
 
-- **模型驱动** —— 摘要由模型自己书写，没有第二次 LLM 摘要调用（ACP 的成本优势）
+- **模型驱动** —— 摘要由模型自己书写，没有第二次 LLM 摘要调用
 - **只建议、不强令** —— 自动策略只 *nudge*（提醒），是否压缩、何时压缩由模型决定
 - **持久且可恢复** —— 压缩范围成为 checkpoint 节点，原文保留在 append-only 会话日志中；`decompress` 可恢复，`search_context` 可在块内查找
-- **基于 seq 引用** —— 不需要消息标签；surface seq 由 nudge 的范围表携带，范围边界自动平衡、容忍 `#callId` 片段
+- **长任务稳得住** —— 每一步都接着前面的成果走，关键结论持续可用、不断叠加，超长任务更容易跑完
+- **上下文始终精简** —— 每次请求都只用少量、精炼的上下文，只保留关键信息；不做大段统一压缩，细节不随之衰失，token 消耗自然更低
 
 这是 [billion-context-pi](https://github.com/ranxianglei/billion-context-pi)（Pi 编码代理适配器）在 DeepSeek Harness 上的移植：压缩内核（[acp-kernel](https://github.com/ranxianglei/acp-kernel)）原样复用，适配层针对 DSH 的 durable-surface 模型重写——经过验证的映射关系见 [docs](https://github.com/Tyan66666/billion-context-dsh/tree/main/docs)。
 


### PR DESCRIPTION
## 变更

替换 README「为什么？/ Why?」里过于技术化的 **基于 seq 引用** 一条（对新人无意义），改为两条贴近实际收益的优势：

- **长任务稳得住** —— 每一步接着前面的成果走，关键结论持续可用，超长任务更容易跑完
- **上下文始终精简** —— 每次请求只携带少量精炼上下文，不做大段统一压缩，细节不衰失，token 消耗自然更低

同时删掉 **模型驱动** 一条里的成本话术（ACP 的成本优势），经济效果只保留在「上下文始终精简」一处，避免成本话题讲两遍。

- README.md / README.en.md 同步修改
- 收益点源于真实使用反馈：长期攻坚任务从"反复重做搞不定"到成果跨轮复用；按 token 计费下节省明显