### PR TITLE
(chore) bump acp-kernel 0.0.24 → 0.0.29 — truly inline via tsup noExternal (move to devDeps)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ Design decisions (see docs/dsh-porting-verification.md for the full evidence):
 2. **Seq is the ref** — no `<acp>` tags; the nudge's range table carries surface seqs.
 3. **No automatic summarization** — `compactIfNeeded` returns null; nudges are advisory, never imperative (default copy aligned with kernel/pi: efficiency note, not "suggestion, not a requirement"; the emergency tier alone says "compress now").
 4. **Model-driven summaries** — the model writes the summary via `compress`; no second LLM summarization call.
-5. **`acp-kernel` pinned to an exact version** (e.g. `"acp-kernel": "0.0.24"`, NEVER `^`). It is inlined by tsup; a caret range breaks reproducibility.
+5. **`acp-kernel` pinned to an exact version** (e.g. `"acp-kernel": "0.0.29"`, NEVER `^`). It is inlined by tsup; a caret range breaks reproducibility.
 6. **Search trusts the kernel** — `search_context` feeds the rebuilt doc set straight to `searchBlocks` (hybrid) and surfaces the scores; the engine adds NO second-tier gate/threshold (an early BM25 no-match gate was removed after it killed 6/46 real queries — synonyms and stemmed matches that hybrid would have found). A low fuzzy-only score (≈0.3 ceiling on noise) is for the model to judge from the surfaced score, not for the engine to filter. Algorithm bugs belong in acp-kernel, never re-implemented here.
 
 ## 3. Hard-won rules (from v0.1.1 long-session battle)
@@ -91,7 +91,7 @@ The PR title is enforced by CI (`.github/workflows/pr-lint.yml` → `scripts/che
 
 ## 4b. acp-kernel upgrade policy (the kernel WILL move on)
 
-`acp-kernel` is pinned **exactly** (e.g. `0.0.24`, never `^`) because tsup inlines it — a caret range makes the resolved version drift when the lockfile regenerates, breaking reproducible builds. But pinning is **not** freezing: upgrades are a controlled, manual process.
+`acp-kernel` is pinned **exactly** (e.g. `0.0.29`, never `^`) because tsup inlines it — a caret range makes the resolved version drift when the lockfile regenerates, breaking reproducible builds. But pinning is **not** freezing: upgrades are a controlled, manual process.
 
 **When to check:** on any feature work, or monthly — `npm view acp-kernel version`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
 			"name": "billion-context-dsh",
 			"version": "0.2.4",
 			"license": "MIT",
-			"dependencies": {
-				"acp-kernel": "0.0.24"
-			},
 			"devDependencies": {
 				"@deepseek-ai/cordis": "4.0.1",
 				"@deepseek-ai/dsh-agent": "0.1.0-rc.6",
@@ -22,6 +19,7 @@
 				"@deepseek-ai/dsh-tools": "0.1.0-rc.6",
 				"@deepseek-ai/schemastery": "3.18.1",
 				"@types/node": "^26.1.2",
+				"acp-kernel": "0.0.29",
 				"tsup": "^8.5.1",
 				"tsx": "^4.23.1",
 				"typescript": "^7.0.2"
@@ -1567,9 +1565,10 @@
 			}
 		},
 		"node_modules/acp-kernel": {
-			"version": "0.0.24",
-			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.24.tgz",
-			"integrity": "sha512-vuNpkTjeTvNprqTRSlFCRuVpqoqdyHY00ejS+lRfdqQYfrOtA2LgfJNF3Aun7ibu2d+llaA6H5WYznpGkJNC/A==",
+			"version": "0.0.29",
+			"resolved": "https://registry.npmjs.org/acp-kernel/-/acp-kernel-0.0.29.tgz",
+			"integrity": "sha512-6o9ynFTpFaMd7KfnPXdYEOcXKxzwBjUXQ6e/DeALqjgcHLZV84CUQUTtoraxbId6YFfTY/kZGVu+zg6faOWNBg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=20"

--- a/package.json
+++ b/package.json
@@ -45,14 +45,12 @@
 		"build": "tsup && tsc --emitDeclarationOnly",
 		"test": "node --import tsx --test tests/*.test.ts"
 	},
-	"dependencies": {
-		"acp-kernel": "0.0.24"
-	},
 	"peerDependencies": {
 		"@deepseek-ai/cordis": "^4.0.1",
 		"@deepseek-ai/dsh-compaction": "^0.1.0-rc.6"
 	},
 	"devDependencies": {
+		"acp-kernel": "0.0.29",
 		"@deepseek-ai/cordis": "4.0.1",
 		"@deepseek-ai/dsh-agent": "0.1.0-rc.6",
 		"@deepseek-ai/dsh-commands": "0.1.0-rc.6",

--- a/src/region.ts
+++ b/src/region.ts
@@ -28,6 +28,8 @@ export interface AcpBlockLedgerEntry {
   /** The compaction transaction id (stable block identity). */
   readonly blockId: string
   readonly summary: string
+  /** The block's short label (kernel `CompressionBlock.topic`), when the compress request carried one. */
+  readonly topic?: string
   readonly shadowedSeqs: readonly number[]
   readonly shadowedTokenCount: number
   readonly start: number
@@ -309,6 +311,8 @@ export interface CompactionTransactionInput {
   readonly shadowedTokenCount: number
   readonly provider: string
   readonly model: string
+  /** Short block label (kernel `CompressionBlock.topic`) — persisted so a restarted engine rehydrates it. */
+  readonly topic?: string
   /** Compression tier of this block (default 1). */
   readonly tier?: 1 | 2 | 3
   /** The acp-kernel block id (`bN`) created by the kernel for this transaction. */
@@ -328,6 +332,8 @@ export interface CompactionTransactionInput {
 export interface AcpCompactionSummaryFields {
   /** Compression tier (1/2/3) — 1 = message range, 2 = distills tier-1, 3 = distills tier-2. */
   readonly tier?: 1 | 2 | 3
+  /** Short block label (kernel `CompressionBlock.topic`) — the acp_status block title. */
+  readonly topic?: string
   /** The acp-kernel block id (`bN`) created for this transaction. */
   readonly kernelBlockId?: string
   /** Durable compaction ids of the blocks distilled into this one. */
@@ -373,6 +379,7 @@ export function runCompactionTransaction(
     model: input.model,
     tier: input.tier ?? 1,
     ...(input.kernelBlockId === undefined ? {} : { kernelBlockId: input.kernelBlockId }),
+    ...(input.topic === undefined ? {} : { topic: input.topic }),
     ...(input.parentBlockIds === undefined || input.parentBlockIds.length === 0
       ? {}
       : { parentBlockIds: [...input.parentBlockIds] }),
@@ -428,6 +435,7 @@ export function rebuildBlockLedger(events: readonly SessionEvent[]): AcpBlockLed
     ledger.push({
       blockId: data.compactionId,
       summary: extractText(data.summary),
+      ...(typeof data.topic === 'string' ? { topic: data.topic } : {}),
       shadowedSeqs: [...data.shadowedSeqs],
       shadowedTokenCount,
       start: data.shadowedRange.start,

--- a/src/state.ts
+++ b/src/state.ts
@@ -71,6 +71,7 @@ function rebuildKernelBlocks(events: readonly SessionEvent[]): CompressionBlock[
       runId: `r${blocks.length + 1}`,
       tier: entry.tier,
       summary: entry.summary,
+      ...(entry.topic === undefined ? {} : { topic: entry.topic }),
       directMessageIds: [...direct],
       effectiveMessageIds: [...effective],
       directBlockIds: parentKernelIds.get(entry.blockId) ?? [],

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -378,6 +378,7 @@ async function handleCompress(env: ToolEnvironment, args: CompressArgs, exec: To
       model: agent.options.model ?? '',
       tier,
       kernelBlockId: block.blockId,
+      ...(range.topic === undefined ? {} : { topic: range.topic }),
       ...(parentBlockIds.length === 0 ? {} : { parentBlockIds }),
       // Record the kernel block's raw coverage so a restarted engine
       // rehydrates the SAME effective messages (a tier-2 block's coverage is

--- a/tests/state.test.ts
+++ b/tests/state.test.ts
@@ -98,3 +98,33 @@ test('M2: rehydrated blocks stay anchorable — tier 3 works after a restart', a
   assert.deepEqual(after[2]!.parentBlockIds, [ledger2[1]!.blockId])
   assert.equal(after[2]!.kernelBlockId, 'b3', 'the post-restart kernel block id is recorded too')
 })
+
+test('M2: block topic persists through the log — the acp_status block title survives a restart', async () => {
+  const env = makeEnv()
+  const session = buildTextSession(12)
+  const compress = toolOf(env, 'compress')
+  await compress.execute({
+    content: [{ startSeq: 1, endSeq: 5, summary: TIER_SUMMARY, topic: 'auth subsystem' }],
+  } as never, fakeExec(session))
+
+  // The durable compaction/summary event and the log-rebuilt ledger carry the topic.
+  const ledger = rebuildBlockLedger(session.events)
+  assert.equal(ledger[0]!.topic, 'auth subsystem')
+
+  // A FRESH store (restarted engine) rehydrates the kernel block WITH the
+  // topic, so buildStatusReport's `block.topic` block-title row survives.
+  const fresh = new AcpStateStore()
+  const state = fresh.stateFor(session)
+  assert.equal(state.blocks[0]!.topic, 'auth subsystem')
+
+  // Optional semantics: a compress without topic records no topic field, and
+  // the rehydrated block has none (kernel renders "(no topic)" — unchanged).
+  const plain = buildTextSession(12)
+  await toolOf(env, 'compress').execute({
+    content: [{ startSeq: 1, endSeq: 5, summary: TIER_SUMMARY }],
+  } as never, fakeExec(plain))
+  const plainLedger = rebuildBlockLedger(plain.events)
+  assert.equal(plainLedger[0]!.topic, undefined)
+  const plainState = new AcpStateStore().stateFor(plain)
+  assert.equal(plainState.blocks[0]!.topic, undefined)
+})

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -2,8 +2,11 @@ import { defineConfig } from 'tsup'
 
 // Bundle the adapter into one self-contained dist/index.js. acp-kernel is
 // deliberately INLINED (not external), matching billion-context-pi: zero
-// runtime deps. The @deepseek-ai/* seam packages stay external — the hosting
-// DSH deployment provides them.
+// runtime deps. tsup externalizes `dependencies` BY DEFAULT, so the inline
+// requires an explicit noExternal — without it dist/index.js ships
+// `import ... from "acp-kernel"` and the published package silently gains a
+// runtime dep (this exact drift shipped through v0.2.4). The @deepseek-ai/*
+// seam packages stay external — the hosting DSH deployment provides them.
 export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm'],
@@ -12,4 +15,5 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   external: [/^@deepseek-ai\//],
+  noExternal: ['acp-kernel'],
 })


### PR DESCRIPTION
## Summary

Upgrade the pinned `acp-kernel` from **0.0.24 → 0.0.29** (per AGENTS.md §4b upgrade SOP) and fix a long-standing build drift: the kernel is now **actually inlined** into `dist/index.js`.

## Changes

- **`package.json` / `package-lock.json`**: `acp-kernel` `0.0.24` → `0.0.29`, moved from `dependencies` to `devDependencies` (it is only needed at build time once inlined).
- **`tsup.config.ts`**: added `noExternal: ['acp-kernel']` — tsup externalizes `dependencies` by default, so without this the published package silently shipped `import ... from "acp-kernel"` plus a runtime dep (verified: **v0.2.4's published tarball had 8 external acp-kernel imports**, contradicting the "zero runtime deps / inlined" docs). Now the docs are true.
- **`AGENTS.md`**: pinned-version references 0.0.24 → 0.0.29.

## What's new in 0.0.29 (vs 0.0.24) — all seam-compatible, nothing adopted silently

| Area | Change | Impact on us |
|---|---|---|
| `CompressionState` | new `tokenSnapshot` field (required, kernel-managed) | additive; we construct state via `createInitialState()`, nothing to do |
| `CompressibleRange` | new optional `chars` | additive; we self-compute the range table |
| `recommend` | T1 gate now counts real chars (not `tokens*4`) | we don't use kernel `compressibleRanges` (rule 3) |
| `search` | `Intl.Segmenter` CJK word segmentation + 2-char CJK fuzzy gate + memoized per-doc features (doc-cache) | in-kernel behavior; our 4 search regression tests still pass unchanged |
| `createBpeTokenizer` | 100K-char size guard fallback | we use `defaultCountTokens`, N/A |
| new exports | `renderWithSnapshot`, `resolveTransformChannel`, `./wire` subpath, `docFeatures`/`setDocCacheCap` | not adopted (no ref rendering / wire channel in DSH surface model) |

## Verification (all green)

- `npm run typecheck` — strict TS, no errors
- `npm test` — **108/108** (all battle-hardened regression tests, incl. the 4 search hybrid-retrieval tests)
- `npm run build` — dist grows 76.87 KB → 177.14 KB (kernel inlined); `grep 'from "acp-kernel"' dist/index.js` = 0
- Standalone smoke test with `node_modules/acp-kernel` **hidden**: `resolveAcpConfig` / `kernelConfigFor` / `AcpStateStore` all work from the bundle; thresholds correct (0.45–0.70 / 0.85)
- `npm pack` — published manifest has **no dependencies**, packed dist has **0 acp-kernel imports**, `Intl.Segmenter` (0.0.29 CJK segmenter) present

## Docs sync

`AGENTS.md` version references updated; `tsup.config.ts` comment now documents why `noExternal` is required. `docs/acp-status-align-design.md` keeps its 0.0.24 pin as a historical verification record (precedent: v0.1.9 bumped only AGENTS.md).

Release (v0.2.5, per §5) can follow once merged.


---

## Update: fix block topic persistence (found during live persistence test)

Live persistence verification caught a real gap: 0.0.29 `buildStatusReport` renders the block title from `CompressionBlock.topic` (`block.topic ?? "(no topic)"`), but the durable `compaction/summary` event never recorded it — block `dfac0574` showed its topic pre-restart and degraded to `(no topic)` after restart. Fixed end to end: compress args → kernel spec (existing) → event field → `rebuildBlockLedger` → `rebuildKernelBlocks`. Regression test added; 109/109 tests pass; dist rebuilt.

**Persistence verification result (live, PID 45415 → 72767 → 84528):** block b1 rehydrates from the log after restart — decompress/search/status all work; only the topic title was lost, now fixed.
