### PR TITLE
(fix) /acp status lists all compressed blocks, not just the oldest 10

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -57,7 +57,10 @@ async function statusText(env: ToolEnvironment, agent: Agent): Promise<string> {
       lines.push(`  next nudge: ~${toNudge.toLocaleString()} tokens to go (usage ${Math.round(nudge.contextUsage * 100)}% → ${Math.round(maxPct * 100)}% line)`)
     }
   }
-  for (const block of ledger.slice(0, 10)) {
+  // Show ALL blocks, not just the oldest 10: /acp status is how the user
+  // confirms recent work survived compression, and the block list is folded
+  // in the GUI anyway, so length has no cost (issue #47).
+  for (const block of ledger) {
     const tier = block.tier > 1 ? ` [T${block.tier}]` : ''
     lines.push(`  - ${block.blockId.slice(0, 8)}${tier}: seqs ${block.start}..${block.end} — ${block.summary.slice(0, 80)}`)
   }

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -113,6 +113,48 @@ test('M4: /acp status lists compressed blocks from the ledger', async () => {
   assert.match(text, /\n  - [0-9a-f]{8}: seqs /, 'block listing line')
 })
 
+test('M4: /acp status lists ALL blocks, not just the oldest 10 (issue #47)', async () => {
+  const env = makeEnv(128000)
+  // 70 messages = 12 non-overlapping 5-message compress ranges (1..60), with
+  // the last 10 messages left live so no range hits the kernel protected zone
+  // (the last 5 messages are never compressible).
+  const session = buildSession(70)
+  const { makeTools } = await import('../src/tools.ts')
+  const compress = makeTools(env).find((definition) => definition.name === 'compress')!
+  const agent = fakeAgent(session)
+
+  const blockPrefixes: string[] = []
+  for (let batch = 0; batch < 12; batch += 1) {
+    const start = batch * 5 + 1
+    const result = await compress.execute({
+      content: [{
+        startSeq: start,
+        endSeq: start + 4,
+        summary: `Batch ${batch}: authentication subsystem, JWT access tokens with 15 minute expiry, refresh tokens in Redis with 30 day TTL, login flow in src/auth/login.ts with sliding-window rate limiting.`,
+      }],
+    } as never, {
+      callId: `call-batch-${batch}`,
+      name: 'compress',
+      arguments: {},
+      signal: new AbortController().signal,
+      agent,
+    } as never) as { text: string }
+    const prefix = result.text.match(/block ([0-9a-f]{8})/)?.[1]
+    assert.ok(prefix !== undefined, `batch ${batch} lands a block`)
+    blockPrefixes.push(prefix)
+  }
+  assert.equal(blockPrefixes.length, 12, '12 batches → 12 blocks')
+
+  const text = await runAcp(env, agent, 'status')
+  assert.ok(text.includes('blocks: 12'), 'ledger counts all 12 blocks')
+  // The old slice(0, 10) hid everything past the 10th block — the 11th and
+  // 12th must now be listed (issue #47 regression).
+  assert.ok(text.includes(blockPrefixes[10]!), `11th block ${blockPrefixes[10]} is listed`)
+  assert.ok(text.includes(blockPrefixes[11]!), `12th block ${blockPrefixes[11]} is listed`)
+  const listingLines = text.split('\n').filter((line) => /^  - [0-9a-f]{8}: seqs /.test(line))
+  assert.equal(listingLines.length, 12, 'all 12 block rows are listed')
+})
+
 test('M4: /acp decompress resolves both the compaction-id prefix and the kernel bN ref', async () => {
   const env = makeEnv(128000)
   const session = buildSession(12)


### PR DESCRIPTION
## Summary

The human-side `/acp status` slash command truncated the block ledger to `ledger.slice(0, 10)` — the 10 OLDEST blocks (ledger is ordered by event time). Recent work was invisible: e.g. a cross-session-memory design block at position 32 of 33 did not appear, making the user believe the content was lost.

The block list is folded in the GUI anyway, so length costs nothing — list **every** block (issue #47).

## Change

`src/commands.ts` — `ledger.slice(0, 10)` → `ledger`, with a comment explaining the rationale.

## Regression test

`tests/commands.test.ts` — new test "M4: /acp status lists ALL blocks, not just the oldest 10 (issue #47)": 12 non-overlapping compress ranges → 12 blocks; asserts the **11th and 12th** block prefixes appear in the output (the old `slice(0, 10)` fails this). Note: the session uses 70 messages so no range hits the kernel protected zone (last 5 messages).

## Verification

- `npm run typecheck` ✅
- `npm test` — **153 pass** (was 152 + 1 new) ✅
- `npm run build` ✅

Closes #47