### PR TITLE
docs: plain-language writing rules — human-facing text must be readable at first sight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,15 @@ npm run build       # tsup (inlines acp-kernel) + tsc --emitDeclarationOnly
 - **Docs must stay in sync with every PR** — before opening a PR, review the diff against the documentation: any behavior the change alters must match what the docs describe, and docs that state the old behavior must be updated in the same PR. A PR that changes behavior without touching docs is incomplete.
 - **Feature work MUST document itself** — every feature (any behavior addition or change) must add an explanation of the new capability in the relevant docs: user-facing config/options in `README.md` / `README.en.md`, install-time composition options in `docs/INSTALL.md`, design decisions in `docs/*-design.md`, and the module map / hard-won rules in `AGENTS.md` itself. Precedent: the `config.prompts` feature shipped its README section, INSTALL note, config table row, and design doc in the same PR.
 
+### Plain-language writing (all human-facing text)
+
+Every piece of human-facing text — PR titles, PR descriptions, commit messages, code comments, docs — is written for a reader seeing it for the first time: no jargon, no private shorthand. If it can't be grasped in ~10 seconds by someone who has never seen the project, rewrite it.
+
+- **PR title**: one sentence saying what changed and what problem it fixes, phrased like you'd tell a teammate (it becomes the main-branch commit via squash).
+- **PR description**: organized as problem → cause → fix → verification; assume the reader doesn't know internal terms or abbreviations.
+- **Code comments**: explain WHY (background, the trap, the premise) — never restate what the code does.
+- **Commit messages**: plain-language subject; add a body only when there's background worth keeping.
+
 ### Commit messages
 
 The convention applies to the **squash-merge subject on main**, which IS the PR title (main is branch-protected; see §5). **Commits inside a PR are free-form** — only the final squash subject is constrained. Single-line subject, prefix by change kind (the description after the prefix is free-form, keep it informative):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,10 @@ npm run build       # tsup bundle
 - Every bug fix ships with a regression test (AGENTS.md §4).
 - `acp-kernel` upgrades follow the manual SOP in AGENTS.md §4b — don't bump the version yourself.
 
+## Writing for readers
+
+Assume the reader sees your PR title, description, and commit message for the first time — no internal jargon, no abbreviations. PR title = one sentence on what changed and what problem it fixes; PR description = problem → cause → fix → verification. See AGENTS.md §4 (Plain-language writing).
+
 ## Commit convention
 
 `main` only accepts **squash merges**: the commit landed on main IS the **PR title**, which must match one of the formats below. **Commits inside a PR are intentionally unconstrained** — the squash subject is what matters.


### PR DESCRIPTION
docs-only change: add a "Plain-language writing" rule so all human-facing text is readable by someone seeing it for the first time.

## Problem
The repo already enforced commit-message FORMAT (prefix + one-line subject via CI), but nothing told writers what good CONTENT looks like. PR titles and descriptions drifted toward internal shorthand, which costs readers — including yourself 6 months later — because the PR title becomes the permanent main-branch commit message.

## Cause
AGENTS.md §4 and CONTRIBUTING.md specified the format conventions (prefix kinds, squash-merge title) but had no content-level guidance on readability.

## Fix
Added a `Plain-language writing` section to AGENTS.md §4 (before Commit messages): PR titles say what changed and what problem it fixes, PR descriptions follow problem → cause → fix → verification, comments explain WHY not what, commit subjects stay plain. Mirrored a short version in CONTRIBUTING.md under "Writing for readers" so contributors see it in the workflow doc too.

## Verification
- 2 files changed, +13 lines, docs-only (no code, no tests needed)
- `git diff` reviewed; AGENTS.md and CONTRIBUTING.md now agree with each other
- Existing recent PR titles already fit the rule (e.g. "(fix) /acp status lists all compressed blocks, not just the oldest 10"), so this codifies current practice rather than adding new constraints
