### PR TITLE
docs: plain-language never means lossy — keep function/param/path/line anchors as grep-able evidence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,7 @@ Every piece of human-facing text — PR titles, PR descriptions, commit messages
 - **PR description**: organized as problem → cause → fix → verification; assume the reader doesn't know internal terms or abbreviations.
 - **Code comments**: explain WHY (background, the trap, the premise) — never restate what the code does.
 - **Commit messages**: plain-language subject; add a body only when there's background worth keeping.
+- **Plain ≠ lossy**: rewriting for readability never means deleting the precise anchors — function names, variable names, parameter names, file paths, and line numbers stay verbatim. They are the grep-able evidence; the rewrite reshapes the narrative, not the substance (lesson: issue #46 v1 over-deleted `collectVisible`/dist line numbers/the options table — the user caught it and it had to be restored).
 
 ### Commit messages
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ npm run build       # tsup bundle
 
 ## Writing for readers
 
-Assume the reader sees your PR title, description, and commit message for the first time — no internal jargon, no abbreviations. PR title = one sentence on what changed and what problem it fixes; PR description = problem → cause → fix → verification. See AGENTS.md §4 (Plain-language writing).
+Assume the reader sees your PR title, description, and commit message for the first time — no internal jargon, no abbreviations. PR title = one sentence on what changed and what problem it fixes; PR description = problem → cause → fix → verification. Plain, however, never means lossy: keep the precise anchors (function names, parameter names, file paths, line numbers) verbatim — they are the grep-able evidence. See AGENTS.md §4 (Plain-language writing).
 
 ## Commit convention
 


### PR DESCRIPTION
## 问题

"人话"改写很容易变成"删信息"：上轮改写 issue #46 时，我为了可读性把 `collectVisible`、dist 行号、方案对比表等精确锚点全删了，你纠正了两次——PR #123 要求保留函数/变量/参数，issue #46 要求 v2 补回技术锚点。这条教训没有写进规范，下次还会再犯。

## 原因

AGENTS.md §4 现有的 Plain-language writing 小节只有 4 条 bullet（PR title / description / code comments / commit messages），只约束"可读"，没有约束"别丢信息"。而技术锚点（函数名、参数名、路径、行号）是**可 grep 的证据**——丢了它们，读者无法复核，人话化就变成了信息丢失。

## 改法

- **AGENTS.md** §4 Plain-language writing 小节新增第 5 条 bullet：**Plain ≠ lossy** — rewriting for readability never means deleting the precise anchors（函数名/变量名/参数名/路径/行号逐字保留），并附上 issue #46 v1 的教训。
- **CONTRIBUTING.md** Writing for readers 小节同步补一句 "Plain, however, never means lossy"，与 AGENTS.md 保持一致。

## 验证

- 纯文档改动（2 files, +2/-1），无代码/行为变更，typecheck/test/build 不受影响。
- 规则本身即自查样例：PR 标题一句话、描述按 问题→原因→改法→验证，且保留了全部技术锚点（`collectVisible`、§4、issue #46）。
