### PR TITLE
(fix) use the detected context window in acp_status and compress

### DIFF
--- a/docs/acp-status-align-design.md
+++ b/docs/acp-status-align-design.md
@@ -192,6 +192,8 @@ buildStatusReport(state: CompressionState, messages: CoreMessage[], countTokens:
 
 **tokenCount 口径（P2-2）**：`handleStatus` 调 `processTurn` 时 `tokenCount` 用 `resolveTokenCount(agent, surfaceMessages)`（surface 口径，与 `handleCompress`/`buildNudge` 一致，遵守硬性规则 2）；**不持久化 turn.state**（`env.store.set` 不调用），避免同 turn 二次推进 nudge 基线、`Nudge:` 行只用 `turn.nudge.reason`。
 
+**窗口来源（issue #63）**：`config.modelContextLimit` 不再是 `env.modelContextLimit`（128K 初始兜底），而是经 `windowFor(agent)` 探测后的有效窗口——`handleCompress` / `handleStatus` 与人类侧 `statusText` 统一走 `resolveEffectiveWindow(env, agent)`（`src/tools.ts`），再 `kernelConfigFor({ ...env, modelContextLimit: window.limit })`。模型工具只消费探测后的窗口进 nudge 决策（规则 9：窗口行不进工具输出），窗口来源的人类可见性由 `/acp` 的 `context window:` 行承担。
+
 ### 4.3 人类 `/acp` 命令
 
 `src/commands.ts:23-45` `statusText` **保留窗口行**（对齐上游 `/acp` 面板语义：人类排查需要窗口）。`/acp` 与模型工具**不强制共用渲染函数**（P2-4）：改后两条路径分叉（模型工具走 kernel 渲染、`/acp` 保留现状窗口格式），且现状两函数本就有差异（`handleStatus` 有 `surface:` 行、`statusText` 无；`statusText` 块行带 `[T${tier}]` 标签、`handleStatus` 不带）。可共享的仅"ledger→块列表行"这一小段，列为可选重构，不引入耦合。`/acp` 输出保持现状：

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -6,7 +6,7 @@
 
 import type { CommandDefinition } from '@deepseek-ai/dsh-commands'
 import type { Agent } from '@deepseek-ai/dsh-agent'
-import type { ToolEnvironment } from './tools.ts'
+import { resolveEffectiveWindow, type ToolEnvironment } from './tools.ts'
 import { resolveTokenCount } from './nudge.ts'
 import { kernelConfigFor } from './config.ts'
 import {
@@ -32,9 +32,7 @@ async function statusText(env: ToolEnvironment, agent: Agent): Promise<string> {
   const coreMessages = allLogMessages(session)
   const surfaceMessages = eventsToCoreMessages(surfaceEventsOf(session))
   const estimated = resolveTokenCount(agent, surfaceMessages)
-  const window = env.windowFor === undefined
-    ? { limit: env.modelContextLimit, source: 'explicit' as const }
-    : await env.windowFor(agent)
+  const window = await resolveEffectiveWindow(env, agent)
   const limit = window.limit
   const lines = [
     `ACP status — session ${session.id}`,

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -253,7 +253,10 @@ async function handleCompress(env: ToolEnvironment, args: CompressArgs, exec: To
   const coreMessages = allLogMessages(session)
   const surfaceMessages = eventsToCoreMessages(surfaceEventsOf(session))
   const tokenCount = resolveTokenCount(agent, surfaceMessages)
-  const config = kernelConfigFor(env)
+  const window = env.windowFor === undefined
+    ? { limit: env.modelContextLimit, source: 'explicit' as const }
+    : await env.windowFor(agent)
+  const config = kernelConfigFor({ ...env, modelContextLimit: window.limit })
 
   // Assign refs / advance state exactly like a turn would.
   const turn = env.kernel.processTurn({ messages: coreMessages, state, config, tokenCount })
@@ -662,7 +665,10 @@ async function handleStatus(env: ToolEnvironment, rawArgs: StatusArgs, exec: Too
   const coreMessages = allLogMessages(session)
   const surfaceMessages = eventsToCoreMessages(surface, toolNames)
   const tokenCount = resolveTokenCount(agent, surfaceMessages)
-  const config = kernelConfigFor(env)
+  const window = env.windowFor === undefined
+    ? { limit: env.modelContextLimit, source: 'explicit' as const }
+    : await env.windowFor(agent)
+  const config = kernelConfigFor({ ...env, modelContextLimit: window.limit })
   // Run the same pipeline the context transform runs, so what acp_status
   // reports matches what the model actually receives. The returned turn.state
   // carries the freshly assigned refs; it is NOT persisted — acp_status is a

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -79,6 +79,20 @@ function requireAgent(exec: ToolRunContext): Agent {
   return exec.agent
 }
 
+/**
+ * Resolve the effective context window for a tool or command run: probe the
+ * agent's real window via `windowFor` when provided, otherwise fall back to
+ * the environment's `modelContextLimit`. Shared by the compress and
+ * acp_status tool handlers and the `/acp` command so the resolution logic
+ * lives in exactly one place (issue #63 — the tools used the 128K fallback
+ * for pressure decisions even when auto-detection had found a larger window).
+ */
+export async function resolveEffectiveWindow(env: ToolEnvironment, agent: Agent): Promise<AcpWindow> {
+  return env.windowFor === undefined
+    ? { limit: env.modelContextLimit, source: 'explicit' as const }
+    : await env.windowFor(agent)
+}
+
 const compressParameters = {
   // Tolerated wrapped-arguments form: some models emit
   // `{ "arguments": "{\"content\": [...]}" }` (double-nested) or
@@ -253,9 +267,7 @@ async function handleCompress(env: ToolEnvironment, args: CompressArgs, exec: To
   const coreMessages = allLogMessages(session)
   const surfaceMessages = eventsToCoreMessages(surfaceEventsOf(session))
   const tokenCount = resolveTokenCount(agent, surfaceMessages)
-  const window = env.windowFor === undefined
-    ? { limit: env.modelContextLimit, source: 'explicit' as const }
-    : await env.windowFor(agent)
+  const window = await resolveEffectiveWindow(env, agent)
   const config = kernelConfigFor({ ...env, modelContextLimit: window.limit })
 
   // Assign refs / advance state exactly like a turn would.
@@ -665,9 +677,7 @@ async function handleStatus(env: ToolEnvironment, rawArgs: StatusArgs, exec: Too
   const coreMessages = allLogMessages(session)
   const surfaceMessages = eventsToCoreMessages(surface, toolNames)
   const tokenCount = resolveTokenCount(agent, surfaceMessages)
-  const window = env.windowFor === undefined
-    ? { limit: env.modelContextLimit, source: 'explicit' as const }
-    : await env.windowFor(agent)
+  const window = await resolveEffectiveWindow(env, agent)
   const config = kernelConfigFor({ ...env, modelContextLimit: window.limit })
   // Run the same pipeline the context transform runs, so what acp_status
   // reports matches what the model actually receives. The returned turn.state

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -20,6 +20,17 @@ function makeEnv(limit = 128000): ToolEnvironment {
   }
 }
 
+function recordingCore(modelContextLimits: number[]): CompressionCore {
+  const core = createCore({})
+  return {
+    ...core,
+    processTurn(input) {
+      modelContextLimits.push(input.config.modelContextLimit)
+      return core.processTurn(input)
+    },
+  }
+}
+
 /** Minimal agent handle: the tools only read session/options. */
 function fakeExec(session: Parameters<typeof buildTextSession>[0] extends never ? never : import('@deepseek-ai/dsh-session').Session, overrides: Partial<ToolRunContext> = {}): ToolRunContext {
   const agent = {
@@ -44,8 +55,18 @@ function toolOf(env: ToolEnvironment, name: string) {
   return tool
 }
 
-test('M3: compress lands a durable block and shrinks the surface', async () => {
-  const env = makeEnv()
+test('M3: compress lands a durable block, shrinks the surface, and uses the effective context window', async () => {
+  const modelContextLimits: number[] = []
+  const env = {
+    ...makeEnv(),
+    kernel: recordingCore(modelContextLimits),
+    windowFor: async () => ({
+      limit: 1000000,
+      source: 'auto' as const,
+      provider: 'test-provider',
+      model: 'test-model',
+    }),
+  }
   const session = buildTextSession(12)
   const before = session.deriveMessages().length
 
@@ -71,6 +92,7 @@ test('M3: compress lands a durable block and shrinks the surface', async () => {
   assert.equal(ledger.length, 1)
   assert.deepEqual(ledger[0]!.shadowedSeqs, [1, 2, 3, 4, 5])
   assert.ok(ledger[0]!.shadowedTokenCount > 0, 'the ledger records real reclaimed tokens, not 0')
+  assert.deepEqual(modelContextLimits, [1000000], 'compress gives the kernel the auto-detected window, not the 128K fallback')
 })
 
 test('M3: successful compress registers its call id for post-result pair hiding', async () => {
@@ -371,9 +393,11 @@ test('M3: acp_status renders the upstream kernel breakdown without window rows',
   assert.ok(!/context window/.test(filledText), 'still no window row after compression')
 })
 
-test('M3: acp_status never shows the window even when windowFor auto-detects it', async () => {
+test('M3: acp_status uses the auto-detected window for pressure without showing window rows', async () => {
+  const modelContextLimits: number[] = []
   const env = {
     ...makeEnv(),
+    kernel: recordingCore(modelContextLimits),
     windowFor: async () => ({
       limit: 1000000,
       source: 'auto' as const,
@@ -388,6 +412,7 @@ test('M3: acp_status never shows the window even when windowFor auto-detects it'
   // The window is a human-side (/acp) concern; the model tool never sees it.
   assert.ok(!/context window/.test(text), 'window rows stay out of the model tool even with a probed window')
   assert.ok(!/estimated context/.test(text), 'window-occupancy rows stay out of the model tool')
+  assert.deepEqual(modelContextLimits, [1000000], 'acp_status gives the kernel the auto-detected window, not the 128K fallback')
 })
 
 test('M3: acp_status surfaces the ACTIVE nudge decision with a small window and compressible content', async () => {

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -427,6 +427,27 @@ test('M3: acp_status surfaces the ACTIVE nudge decision with a small window and 
   assert.match(text, /Nudge: ACTIVE — /, 'pressure + pending content → kernel injects')
 })
 
+test('M3: acp_status pressure follows the probed window, not the fallback (issue #63 false alarm)', async () => {
+  // Issue #63: the model tool fed the kernel the env FALLBACK window (500),
+  // so the same session read 25× over-limit → ACTIVE false alarm. With the
+  // probed window (1M) the pressure the model sees drops to ~1% → idle. The
+  // ACTIVE test above is the control: without windowFor the fallback path
+  // still arbitrates ACTIVE, so this probe is what defuses the alarm.
+  const env = {
+    ...makeEnv(500),
+    windowFor: async () => ({
+      limit: 1000000,
+      source: 'auto' as const,
+      provider: 'test-provider',
+      model: 'test-model',
+    }),
+  }
+  const session = buildTextSession(12)
+  const status = await toolOf(env, 'acp_status').execute({}, fakeExec(session))
+  const text = (status as { text: string }).text
+  assert.match(text, /Nudge: idle — /, 'probed window defuses the 128K-fallback false alarm')
+})
+
 test('M3: acp_status breakdown does not double-count the checkpoint summary (P1-3)', async () => {
   const env = makeEnv()
   const session = buildTextSession(12)


### PR DESCRIPTION
## Problem

On a model with a 1,000,000-token context window, the human `/acp status` command reports the expected pressure, but the model-facing `acp_status` and `compress` tools can still calculate pressure against the 128,000-token fallback. This inflates usage by about eight times and can produce false over-limit or emergency guidance.

Thank you to @adamqeqj003-dotcom for the detailed diagnosis and proposed correction in #63.

## Cause

`handleStatus` and `handleCompress` passed the startup `ToolEnvironment` directly to `kernelConfigFor`. Automatic window detection is exposed through `windowFor(agent)` and does not mutate that startup object, so these two paths never received the detected limit.

## Fix

Both handlers now:

1. ask `windowFor(agent)` for the effective model window;
2. build the kernel configuration with that detected limit;
3. preserve the existing explicit 128,000 fallback when no resolver is available.

No report formatting or compression policy is reimplemented; the existing kernel receives the correct adapter value.

## Verification

- regression tests record the configuration passed to `processTurn` and prove that both `acp_status` and `compress` receive `1,000,000`, not `128,000`
- `npm test` — 162 passed
- `npm run typecheck` — passed
- `npm run build` — passed

## Documentation review

The README configuration table already states that the automatically detected `modelContextLimit` drives kernel pressure decisions. This patch makes the two model-tool paths match that documented behavior, so no documentation text changes are needed.