### PR TITLE
(chore) auto-sync triage labels to the Roadmap project

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,16 +1,19 @@
 # Issue 打标签时自动同步到 GitHub Project「billion-context-dsh Roadmap」(project #1):
 #   - 新开/改标签的 issue 自动加入项目(已加入则跳过,幂等)
-#   - priority: P0/P1/P2/backlog 标签 → Priority 单选字段
+#   - priority: P0/P1/P2/backlog 标签 → Priority 单选字段(只响应本次事件的标签,
+#     不重算全部标签——避免覆盖人工在项目面板里改过的值)
 #   - upstream-pending 标签 → "Blocked by upstream" 文本字段打勾说明
 # Project V2 写操作走 gh CLI 的 GraphQL,需要 fine-grained PAT(勾选 org project 权限)存在
 # 仓库 secret GH_PROJECT_TOKEN;没有时本 action 静默跳过字段同步步骤。
+# 依赖:docs/upstream-tracker.md 由另一个 PR(#84)先合并进来;watch-upstream job
+#   对该文件缺失有保护(不存在时跳过 tracker 来源,不会报错)。
 # 另有每日定时巡检(docs/upstream-tracker.md 里登记的上游 PR):上游 PR 合并后,
 #   给对应本地 issue 打 upstream-merged 标签并留言提醒 bump kernel(见 job watch-upstream)。
 name: issue-triage
 
 on:
   issues:
-    types: [labeled, opened]
+    types: [labeled, unlabeled, opened]
   schedule:
     - cron: '23 3 * * *'
 
@@ -18,28 +21,32 @@ permissions:
   issues: write
   contents: read
 
-# 定时任务没有 issue number,用固定组即可;事件任务按 issue 去重
+# 定时任务没有 issue number,用固定组即可;事件任务按 issue 去重。
+# 不取消进行中的运行:连续打标签时,取消会把"条目已加、字段未写"留在半途。
+# 两个 job 用独立的并发组:schedule 触发时 sync 不跑,若共用一组,watch-upstream
+# 会被同组的按 issue 分组逻辑意外取消/排队。
 concurrency:
-  group: issue-triage-${{ github.event.issue.number || 'cron' }}
-  cancel-in-progress: true
+  group: issue-triage-sync-${{ github.event.issue.number || 'cron' }}
+  cancel-in-progress: false
 
 jobs:
   sync:
     runs-on: ubuntu-latest
+    if: github.event_name != 'schedule'
     steps:
       - name: Sync issue to Roadmap project
         env:
           GH_TOKEN: ${{ secrets.GH_PROJECT_TOKEN }}
           ISSUE_URL: ${{ github.event.issue.html_url }}
-          LABELS: ${{ join(github.event.issue.labels.*.name, ',') }}
+          # 只看本次事件对应的标签:重放全部标签会覆盖人工在项目面板改过的字段,
+          # 且一个 issue 同时挂 P0+P1 时永远写先匹配的那个。
+          EVENT_LABEL: ${{ github.event.label.name }}
           PROJECT: 1
           OWNER: Tyan66666
-          # Field ids from the project (stable GraphQL node ids)
+          # Priority 单选字段 id(PVTSSF_ 前缀,项目级稳定 node id)。
+          # 选项 id 不再硬编码:运行时按 option name 从 field-list 查完整 node id,
+          # 避免复制时截断(GraphQL 只认完整 PVTSEO_ 前缀 id)。
           PRIORITY_FIELD_ID: PVTSSF_lAHOAluDGs4Bh_qSzhg5Q5Q
-          OPT_P0: '6600f446'
-          OPT_P1: '5e823b78'
-          OPT_P2: 'd831c249'
-          OPT_BACKLOG: '63d3047c'
           UPSTREAM_FIELD_ID: PVTF_lAHOAluDGs4Bh_qSzhg5Q5U
         run: |
           set -euo pipefail
@@ -47,42 +54,53 @@ jobs:
             echo "GH_PROJECT_TOKEN not set — skipping (configure the secret to enable auto-triage)."
             exit 0
           fi
-          # 1) ensure the issue is in the project (idempotent)
-          ITEM_ID=$(gh project item-add "$PROJECT" --owner "$OWNER" --url "$ISSUE_URL" --format json --jq .id 2>/dev/null || true)
+          # projectId 只取一次,两个 mutation 复用
+          PROJECT_ID=$(gh project view "$PROJECT" --owner "$OWNER" --format json --jq .id)
+          # 1) ensure the issue is in the project (idempotent):
+          #    先查是否已存在,不存在再添加——不要靠 item-add 失败再回查,
+          #    那会把 PAT 无效/无权限等真实错误吞掉
+          ITEM_ID=$(gh project item-list "$PROJECT" --owner "$OWNER" --format json \
+            --jq --arg u "$ISSUE_URL" '[.items[] | select(.content.url==$u)][0].id')
           if [ -z "${ITEM_ID:-}" ]; then
-            # already in the project: look the item up
-            ITEM_ID=$(gh project item-list "$PROJECT" --owner "$OWNER" --format json \
-              --jq ".items[] | select(.content.url==\"$ISSUE_URL\") | .id" | head -1)
+            ITEM_ID=$(gh project item-add "$PROJECT" --owner "$OWNER" --url "$ISSUE_URL" --format json --jq .id)
           fi
           if [ -z "${ITEM_ID:-}" ]; then
             echo "Could not resolve project item id for $ISSUE_URL" >&2
             exit 1
           fi
           echo "item: $ITEM_ID"
-          # 2) map priority label → Priority field (single-select)
-          case ",$LABELS," in
-            *,"priority: P0",*)   OPT=$OPT_P0 ;;
-            *,"priority: P1",*)   OPT=$OPT_P1 ;;
-            *,"priority: P2",*)   OPT=$OPT_P2 ;;
-            *,"priority: backlog",*) OPT=$OPT_BACKLOG ;;
-            *) OPT="" ;;
+          # 2) 本次标签 → Priority 字段(single-select)。运行时按名查 option id:
+          #    field-list 一次拿全,后续无需再查。查不到(字段被改名/删除)时报错退出,
+          #    不静默写空值。
+          OPT=""
+          case ",$EVENT_LABEL," in
+            *,"priority: P0",*)   OPT_NAME="P0" ;;
+            *,"priority: P1",*)   OPT_NAME="P1" ;;
+            *,"priority: P2",*)   OPT_NAME="P2" ;;
+            *,"priority: backlog",*) OPT_NAME="backlog" ;;
           esac
-          if [ -n "$OPT" ]; then
+          if [ -n "${OPT_NAME:-}" ]; then
+            OPT=$(gh project field-list "$PROJECT" --owner "$OWNER" --format json \
+              --jq --arg f "$PRIORITY_FIELD_ID" --arg n "$OPT_NAME" \
+              '.fields[] | select(.id==$f) | .options[] | select(.name==$n) | .id')
+            if [ -z "$OPT" ]; then
+              echo "Priority option '$OPT_NAME' not found in project field $PRIORITY_FIELD_ID" >&2
+              exit 1
+            fi
             gh api graphql -f query='mutation($p:ID!,$i:ID!,$f:ID!,$v:String!){
               updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,value:{singleSelectOptionId:$v}})
               { projectV2Item { id } } }' \
-              -f p="$(gh project view "$PROJECT" --owner "$OWNER" --format json --jq .id)" \
-              -f i="$ITEM_ID" -f f="$PRIORITY_FIELD_ID" -f v="$OPT" >/dev/null && echo "priority set"
+              -f p="$PROJECT_ID" -f i="$ITEM_ID" -f f="$PRIORITY_FIELD_ID" -f v="$OPT" \
+              && echo "priority set"
           fi
           # 3) upstream-pending → mark the Upstream field
-          case ",$LABELS," in
+          case ",$EVENT_LABEL," in
             *,"upstream-pending",*)
               gh api graphql -f query='mutation($p:ID!,$i:ID!,$f:ID!,$v:String!){
                 updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,value:{text:$v}})
                 { projectV2Item { id } } }' \
-                -f p="$(gh project view "$PROJECT" --owner "$OWNER" --format json --jq .id)" \
-                -f i="$ITEM_ID" -f f="$UPSTREAM_FIELD_ID" \
-                -f v="上游修复合入后需解除本地 workaround(见 docs/upstream-tracker.md)" >/dev/null \
+                -f p="$PROJECT_ID" -f i="$ITEM_ID" -f f="$UPSTREAM_FIELD_ID" \
+                -f v="上游修复合入后需解除本地 workaround(见 docs/upstream-tracker.md)" \
                 && echo "upstream flag set" ;;
           esac
 
@@ -97,6 +115,9 @@ jobs:
   watch-upstream:
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule'
+    concurrency:
+      group: issue-triage-watch-upstream
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
       - name: Check upstream PRs (tracker doc + issue bodies)
@@ -107,12 +128,18 @@ jobs:
           set -euo pipefail
           # 1) pairs from the tracker doc: same table row must mention both
           #    (issue link and PR link live in different cells, so match row-wise)
-          awk -F'|' '/billion-context-dsh\/issues/ && /acp-kernel\/pull/ {
-            match($0, /billion-context-dsh\/issues\/[0-9]+/); li=substr($0,RSTART,RLENGTH);
-            match($0, /acp-kernel\/pull\/[0-9]+/);            up=substr($0,RSTART,RLENGTH);
-            gsub(/.*issues\//,"",li); gsub(/.*pull\//,"",up);
-            print li" "up
-          }' docs/upstream-tracker.md > pairs.txt || true
+          #    该文件由 PR #84 引入;未合并时文件不存在,跳过这一来源而不是报错
+          if [ -f docs/upstream-tracker.md ]; then
+            awk -F'|' '/billion-context-dsh\/issues/ && /acp-kernel\/pull/ {
+              match($0, /billion-context-dsh\/issues\/[0-9]+/); li=substr($0,RSTART,RLENGTH);
+              match($0, /acp-kernel\/pull\/[0-9]+/);            up=substr($0,RSTART,RLENGTH);
+              gsub(/.*issues\//,"",li); gsub(/.*pull\//,"",up);
+              print li" "up
+            }' docs/upstream-tracker.md >> pairs.txt || true
+          else
+            echo "docs/upstream-tracker.md not found — tracker-source skipped (merge PR #84 to enable)"
+          fi
+          touch pairs.txt
           # 2) pairs from open issue bodies/titles: an issue that pastes an
           #    acp-kernel pull link tracks that PR by itself (multiple links → keep all).
           #    Bodies are multi-line, so jq emits "NUMBER\tTITLE\nBODY" and awk tracks

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -62,7 +62,7 @@ jobs:
           # gh 内置 --jq 只接受单个表达式,不能绑定 --arg 变量(实测 gh 2.88.1 报
           # "accepts at most 1 arg(s)"),带变量的过滤一律管道到系统 jq(ubuntu-latest 预装)。
           ITEM_ID=$(gh project item-list "$PROJECT" --owner "$OWNER" --limit 1000 --format json \
-            | jq -r --arg u "$ISSUE_URL" '[.items[] | select(.content.url==$u)][0].id')
+            | jq -r --arg u "$ISSUE_URL" '[.items[] | select(.content.url==$u)][0].id // empty')
           if [ -z "${ITEM_ID:-}" ]; then
             ITEM_ID=$(gh project item-add "$PROJECT" --owner "$OWNER" --url "$ISSUE_URL" --format json --jq .id)
           fi
@@ -92,7 +92,7 @@ jobs:
           elif [ -n "${OPT_NAME:-}" ]; then
             OPT=$(gh project field-list "$PROJECT" --owner "$OWNER" --format json \
               | jq -r --arg f "$PRIORITY_FIELD_ID" --arg n "$OPT_NAME" \
-              '.fields[] | select(.id==$f) | .options[] | select(.name==$n) | .id')
+              '.fields[] | select(.id==$f) | .options[] | select(.name==$n) | .id // empty')
             if [ -z "$OPT" ]; then
               echo "Priority option '$OPT_NAME' not found in project field $PRIORITY_FIELD_ID" >&2
               exit 1

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -104,10 +104,14 @@ jobs:
           UPSTREAM_REPO: ranxianglei/acp-kernel
         run: |
           set -euo pipefail
-          # collect "local_issue:upstream_pr" pairs from the tracker table
-          grep -oE 'billion-context-dsh/issues/[0-9]+\)?[^|]*acp-kernel/pull/[0-9]+' docs/upstream-tracker.md | \
-            grep -oE 'issues/[0-9]+|pull/[0-9]+' | paste - - | \
-            sed -E 's#issues/([0-9]+)\tpull/([0-9]+)#\1 \2#' > pairs.txt || true
+          # collect "local_issue upstream_pr" pairs — same table row must mention both
+          # (issue link and PR link live in different cells, so match row-wise, not line-wise pairs)
+          awk -F'|' '/billion-context-dsh\/issues/ && /acp-kernel\/pull/ {
+            match($0, /billion-context-dsh\/issues\/[0-9]+/); li=substr($0,RSTART,RLENGTH);
+            match($0, /acp-kernel\/pull\/[0-9]+/);            up=substr($0,RSTART,RLENGTH);
+            gsub(/.*issues\//,"",li); gsub(/.*pull\//,"",up);
+            print li" "up
+          }' docs/upstream-tracker.md > pairs.txt
           if [ ! -s pairs.txt ]; then echo "no tracked upstream PRs"; exit 0; fi
           while read -r ISSUE PR; do
             STATE=$(gh api "repos/$UPSTREAM_REPO/pulls/$PR" --jq '.state + ":" + (.merged|tostring)')

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -59,7 +59,7 @@ jobs:
           # 1) ensure the issue is in the project (idempotent):
           #    先查是否已存在,不存在再添加——不要靠 item-add 失败再回查,
           #    那会把 PAT 无效/无权限等真实错误吞掉
-          ITEM_ID=$(gh project item-list "$PROJECT" --owner "$OWNER" --format json \
+          ITEM_ID=$(gh project item-list "$PROJECT" --owner "$OWNER" --limit 1000 --format json \
             --jq --arg u "$ISSUE_URL" '[.items[] | select(.content.url==$u)][0].id')
           if [ -z "${ITEM_ID:-}" ]; then
             ITEM_ID=$(gh project item-add "$PROJECT" --owner "$OWNER" --url "$ISSUE_URL" --format json --jq .id)
@@ -72,14 +72,22 @@ jobs:
           # 2) 本次标签 → Priority 字段(single-select)。运行时按名查 option id:
           #    field-list 一次拿全,后续无需再查。查不到(字段被改名/删除)时报错退出,
           #    不静默写空值。
-          OPT=""
+          #    unlabeled 移除的是 priority 标签时,清除 Priority 字段(clearProjectV2ItemFieldValue)
+          #    而不是把旧值重写一遍——重写与"移除标签"的意图正好相反。
+          IS_UNLABELED="${{ github.event.action == 'unlabeled' }}"
           case ",$EVENT_LABEL," in
             *,"priority: P0",*)   OPT_NAME="P0" ;;
             *,"priority: P1",*)   OPT_NAME="P1" ;;
             *,"priority: P2",*)   OPT_NAME="P2" ;;
-            *,"priority: backlog",*) OPT_NAME="backlog" ;;
+            *,"priority: backlog",*) OPT_NAME="Backlog" ;;
           esac
-          if [ -n "${OPT_NAME:-}" ]; then
+          if [ "$IS_UNLABELED" = "true" ] && [ -n "${OPT_NAME:-}" ]; then
+            gh api graphql -f query='mutation($p:ID!,$i:ID!,$f:ID!){
+              clearProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f})
+              { projectV2Item { id } } }' \
+              -f p="$PROJECT_ID" -f i="$ITEM_ID" -f f="$PRIORITY_FIELD_ID" \
+              && echo "priority field cleared (label removed)"
+          elif [ -n "${OPT_NAME:-}" ]; then
             OPT=$(gh project field-list "$PROJECT" --owner "$OWNER" --format json \
               --jq --arg f "$PRIORITY_FIELD_ID" --arg n "$OPT_NAME" \
               '.fields[] | select(.id==$f) | .options[] | select(.name==$n) | .id')
@@ -106,7 +114,7 @@ jobs:
 
   # 每日巡检上游 acp-kernel 的 PR。追踪来源取并集:
   #   1. docs/upstream-tracker.md 表格行(本地 issue 链接 + 上游 PR 链接同行出现);
-  #   2. 本仓库开放 issue 的正文/标题里贴的 https://github.com/ranxianglei/acp-kernel/pull/<n>
+  #   2. 本仓库开放 issue 的正文里贴的 https://github.com/ranxianglei/acp-kernel/pull/<n>
   #      ——issue 正文附上游 PR 链接即被自动追踪,无需改 workflow。
   # 上游 PR 已 merged 的,给对应本地 issue 打 upstream-merged 标签并留言。
   # 已打过的不会重复(幂等)。

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,82 @@
+# Issue 打标签时自动同步到 GitHub Project「billion-context-dsh Roadmap」(project #1):
+#   - 新开/改标签的 issue 自动加入项目(已加入则跳过,幂等)
+#   - priority: P0/P1/P2/backlog 标签 → Priority 单选字段
+#   - upstream-pending 标签 → "Blocked by upstream" 文本字段打勾说明
+# Project V2 写操作走 gh CLI 的 GraphQL,需要 fine-grained PAT(勾选 org project 权限)存在
+# 仓库 secret GH_PROJECT_TOKEN;没有时本 action 静默跳过字段同步步骤。
+name: issue-triage
+
+on:
+  issues:
+    types: [labeled, opened]
+
+permissions:
+  issues: read
+  contents: read
+
+concurrency:
+  group: issue-triage-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync issue to Roadmap project
+        env:
+          GH_TOKEN: ${{ secrets.GH_PROJECT_TOKEN }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          LABELS: ${{ join(github.event.issue.labels.*.name, ',') }}
+          PROJECT: 1
+          OWNER: Tyan66666
+          # Field ids from the project (stable GraphQL node ids)
+          PRIORITY_FIELD_ID: PVTSSF_lAHOAluDGs4Bh_qSzhg5Q5Q
+          OPT_P0: '6600f446'
+          OPT_P1: '5e823b78'
+          OPT_P2: 'd831c249'
+          OPT_BACKLOG: '63d3047c'
+          UPSTREAM_FIELD_ID: PVTF_lAHOAluDGs4Bh_qSzhg5Q5U
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "GH_PROJECT_TOKEN not set — skipping (configure the secret to enable auto-triage)."
+            exit 0
+          fi
+          # 1) ensure the issue is in the project (idempotent)
+          ITEM_ID=$(gh project item-add "$PROJECT" --owner "$OWNER" --url "$ISSUE_URL" --format json --jq .id 2>/dev/null || true)
+          if [ -z "${ITEM_ID:-}" ]; then
+            # already in the project: look the item up
+            ITEM_ID=$(gh project item-list "$PROJECT" --owner "$OWNER" --format json \
+              --jq ".items[] | select(.content.url==\"$ISSUE_URL\") | .id" | head -1)
+          fi
+          if [ -z "${ITEM_ID:-}" ]; then
+            echo "Could not resolve project item id for $ISSUE_URL" >&2
+            exit 1
+          fi
+          echo "item: $ITEM_ID"
+          # 2) map priority label → Priority field (single-select)
+          case ",$LABELS," in
+            *,"priority: P0",*)   OPT=$OPT_P0 ;;
+            *,"priority: P1",*)   OPT=$OPT_P1 ;;
+            *,"priority: P2",*)   OPT=$OPT_P2 ;;
+            *,"priority: backlog",*) OPT=$OPT_BACKLOG ;;
+            *) OPT="" ;;
+          esac
+          if [ -n "$OPT" ]; then
+            gh api graphql -f query='mutation($p:ID!,$i:ID!,$f:ID!,$v:String!){
+              updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,value:{singleSelectOptionId:$v}})
+              { projectV2Item { id } } }' \
+              -f p="$(gh project view "$PROJECT" --owner "$OWNER" --format json --jq .id)" \
+              -f i="$ITEM_ID" -f f="$PRIORITY_FIELD_ID" -f v="$OPT" >/dev/null && echo "priority set"
+          fi
+          # 3) upstream-pending → mark the Upstream field
+          case ",$LABELS," in
+            *,"upstream-pending",*)
+              gh api graphql -f query='mutation($p:ID!,$i:ID!,$f:ID!,$v:String!){
+                updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,value:{text:$v}})
+                { projectV2Item { id } } }' \
+                -f p="$(gh project view "$PROJECT" --owner "$OWNER" --format json --jq .id)" \
+                -f i="$ITEM_ID" -f f="$UPSTREAM_FIELD_ID" \
+                -f v="上游修复合入后需解除本地 workaround(见 docs/upstream-tracker.md)" >/dev/null \
+                && echo "upstream flag set" ;;
+          esac

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -59,8 +59,10 @@ jobs:
           # 1) ensure the issue is in the project (idempotent):
           #    先查是否已存在,不存在再添加——不要靠 item-add 失败再回查,
           #    那会把 PAT 无效/无权限等真实错误吞掉
+          # gh 内置 --jq 只接受单个表达式,不能绑定 --arg 变量(实测 gh 2.88.1 报
+          # "accepts at most 1 arg(s)"),带变量的过滤一律管道到系统 jq(ubuntu-latest 预装)。
           ITEM_ID=$(gh project item-list "$PROJECT" --owner "$OWNER" --limit 1000 --format json \
-            --jq --arg u "$ISSUE_URL" '[.items[] | select(.content.url==$u)][0].id')
+            | jq -r --arg u "$ISSUE_URL" '[.items[] | select(.content.url==$u)][0].id')
           if [ -z "${ITEM_ID:-}" ]; then
             ITEM_ID=$(gh project item-add "$PROJECT" --owner "$OWNER" --url "$ISSUE_URL" --format json --jq .id)
           fi
@@ -89,7 +91,7 @@ jobs:
               && echo "priority field cleared (label removed)"
           elif [ -n "${OPT_NAME:-}" ]; then
             OPT=$(gh project field-list "$PROJECT" --owner "$OWNER" --format json \
-              --jq --arg f "$PRIORITY_FIELD_ID" --arg n "$OPT_NAME" \
+              | jq -r --arg f "$PRIORITY_FIELD_ID" --arg n "$OPT_NAME" \
               '.fields[] | select(.id==$f) | .options[] | select(.name==$n) | .id')
             if [ -z "$OPT" ]; then
               echo "Priority option '$OPT_NAME' not found in project field $PRIORITY_FIELD_ID" >&2

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -86,11 +86,12 @@ jobs:
                 && echo "upstream flag set" ;;
           esac
 
-  # 每日巡检 docs/upstream-tracker.md 里登记的上游 PR。
-  # 规则:只认 docs/upstream-tracker.md 里形如
-  #   https://github.com/ranxianglei/acp-kernel/pull/<n>
-  # 的链接;上游 PR 已 merged 的,给「同一表格行引用的本地 issue」
-  # 打 upstream-merged 标签并留言。标签打过的不会重复(幂等)。
+  # 每日巡检上游 acp-kernel 的 PR。追踪来源取并集:
+  #   1. docs/upstream-tracker.md 表格行(本地 issue 链接 + 上游 PR 链接同行出现);
+  #   2. 本仓库开放 issue 的正文/标题里贴的 https://github.com/ranxianglei/acp-kernel/pull/<n>
+  #      ——issue 正文附上游 PR 链接即被自动追踪,无需改 workflow。
+  # 上游 PR 已 merged 的,给对应本地 issue 打 upstream-merged 标签并留言。
+  # 已打过的不会重复(幂等)。
   # 注意:上游合并 ≠ 可以解除 workaround——等 release + bump pin 后,
   # 按 AGENTS.md §4b SOP 人工升级,那时才删 workaround 并把标签换成 resolved。
   watch-upstream:
@@ -98,20 +99,35 @@ jobs:
     if: github.event_name == 'schedule'
     steps:
       - uses: actions/checkout@v4
-      - name: Check upstream PRs from the tracker doc
+      - name: Check upstream PRs (tracker doc + issue bodies)
         env:
           GH_TOKEN: ${{ github.token }}
           UPSTREAM_REPO: ranxianglei/acp-kernel
         run: |
           set -euo pipefail
-          # collect "local_issue upstream_pr" pairs — same table row must mention both
-          # (issue link and PR link live in different cells, so match row-wise, not line-wise pairs)
+          # 1) pairs from the tracker doc: same table row must mention both
+          #    (issue link and PR link live in different cells, so match row-wise)
           awk -F'|' '/billion-context-dsh\/issues/ && /acp-kernel\/pull/ {
             match($0, /billion-context-dsh\/issues\/[0-9]+/); li=substr($0,RSTART,RLENGTH);
             match($0, /acp-kernel\/pull\/[0-9]+/);            up=substr($0,RSTART,RLENGTH);
             gsub(/.*issues\//,"",li); gsub(/.*pull\//,"",up);
             print li" "up
-          }' docs/upstream-tracker.md > pairs.txt
+          }' docs/upstream-tracker.md > pairs.txt || true
+          # 2) pairs from open issue bodies/titles: an issue that pastes an
+          #    acp-kernel pull link tracks that PR by itself (multiple links → keep all).
+          #    Bodies are multi-line, so jq emits "NUMBER\tTITLE\nBODY" and awk tracks
+          #    the most recent issue-number line while scanning paragraphs.
+          gh issue list --state open --limit 200 --json number,title,body \
+            --jq '.[] | "\(.number)\t\(.title)\n\(.body)"' > issues.txt
+          awk -F'\t' '
+            /^[0-9]+\t/ { split($0,a,"\t"); num=a[1]; next }
+            /acp-kernel\/pull\/[0-9]+/ && num != "" {
+              while (match($0, /acp-kernel\/pull\/[0-9]+/)) {
+                s=substr($0,RSTART,RLENGTH); gsub(/.*pull\//,"",s); print num" "s;
+                $0=substr($0,RSTART+RLENGTH)
+              }
+            }' issues.txt >> pairs.txt
+          sort -u pairs.txt -o pairs.txt
           if [ ! -s pairs.txt ]; then echo "no tracked upstream PRs"; exit 0; fi
           while read -r ISSUE PR; do
             STATE=$(gh api "repos/$UPSTREAM_REPO/pulls/$PR" --jq '.state + ":" + (.merged|tostring)')

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -4,18 +4,23 @@
 #   - upstream-pending 标签 → "Blocked by upstream" 文本字段打勾说明
 # Project V2 写操作走 gh CLI 的 GraphQL,需要 fine-grained PAT(勾选 org project 权限)存在
 # 仓库 secret GH_PROJECT_TOKEN;没有时本 action 静默跳过字段同步步骤。
+# 另有每日定时巡检(docs/upstream-tracker.md 里登记的上游 PR):上游 PR 合并后,
+#   给对应本地 issue 打 upstream-merged 标签并留言提醒 bump kernel(见 job watch-upstream)。
 name: issue-triage
 
 on:
   issues:
     types: [labeled, opened]
+  schedule:
+    - cron: '23 3 * * *'
 
 permissions:
-  issues: read
+  issues: write
   contents: read
 
+# 定时任务没有 issue number,用固定组即可;事件任务按 issue 去重
 concurrency:
-  group: issue-triage-${{ github.event.issue.number }}
+  group: issue-triage-${{ github.event.issue.number || 'cron' }}
   cancel-in-progress: true
 
 jobs:
@@ -80,3 +85,37 @@ jobs:
                 -f v="上游修复合入后需解除本地 workaround(见 docs/upstream-tracker.md)" >/dev/null \
                 && echo "upstream flag set" ;;
           esac
+
+  # 每日巡检 docs/upstream-tracker.md 里登记的上游 PR。
+  # 规则:只认 docs/upstream-tracker.md 里形如
+  #   https://github.com/ranxianglei/acp-kernel/pull/<n>
+  # 的链接;上游 PR 已 merged 的,给「同一表格行引用的本地 issue」
+  # 打 upstream-merged 标签并留言。标签打过的不会重复(幂等)。
+  # 注意:上游合并 ≠ 可以解除 workaround——等 release + bump pin 后,
+  # 按 AGENTS.md §4b SOP 人工升级,那时才删 workaround 并把标签换成 resolved。
+  watch-upstream:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check upstream PRs from the tracker doc
+        env:
+          GH_TOKEN: ${{ github.token }}
+          UPSTREAM_REPO: ranxianglei/acp-kernel
+        run: |
+          set -euo pipefail
+          # collect "local_issue:upstream_pr" pairs from the tracker table
+          grep -oE 'billion-context-dsh/issues/[0-9]+\)?[^|]*acp-kernel/pull/[0-9]+' docs/upstream-tracker.md | \
+            grep -oE 'issues/[0-9]+|pull/[0-9]+' | paste - - | \
+            sed -E 's#issues/([0-9]+)\tpull/([0-9]+)#\1 \2#' > pairs.txt || true
+          if [ ! -s pairs.txt ]; then echo "no tracked upstream PRs"; exit 0; fi
+          while read -r ISSUE PR; do
+            STATE=$(gh api "repos/$UPSTREAM_REPO/pulls/$PR" --jq '.state + ":" + (.merged|tostring)')
+            echo "issue #$ISSUE <- upstream PR #$PR: $STATE"
+            [ "$STATE" = "open:false" ] && continue          # 未合并,继续等
+            # 已合并(open:true 不可能出现在 pulls API;closed:true 即已合并)
+            ALREADY=$(gh issue view "$ISSUE" --json labels --jq '[.labels[].name] | join(",")')
+            case ",$ALREADY," in *",upstream-merged,"*) continue ;; esac
+            gh issue edit "$ISSUE" --add-label "upstream-merged" --remove-label "upstream-pending"
+            gh issue comment "$ISSUE" --body "上游 PR [$UPSTREAM_REPO#$PR](https://github.com/$UPSTREAM_REPO/pull/$PR) 已合并 ✅。请在下一次 acp-kernel 升级(AGENTS.md §4b SOP)时:确认已发布包含该修复的版本 → bump pin → 解除本地 workaround → 更新 docs/upstream-tracker.md → 关闭本 issue。"
+          done < pairs.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,3 +57,12 @@ PR titles are enforced by CI (`.github/workflows/pr-lint.yml`, rule in `scripts/
 ## Releasing
 
 See AGENTS.md §5: `npm version` bump → sync version refs in docs → `npm publish` → `release vX.Y.Z` commit → `gh release create` → Pages rebuilds automatically.
+
+## Issue triage automation (labels → Roadmap project)
+
+`.github/workflows/issue-triage.yml` keeps the GitHub Project「billion-context-dsh Roadmap」in sync with issue labels:
+
+- **sync job** — when an issue is opened, labeled, or unlabeled, it is added to project #1 (idempotently), and the label currently applied maps to project fields: `priority: P0/P1/P2/backlog` → the Priority single-select field; `upstream-pending` → a pointer in the Upstream text field (see `docs/upstream-tracker.md`). Only the label from the triggering event is synced — other labels are left untouched.
+- **watch-upstream job** — a daily cron compares the upstream PRs referenced in `docs/upstream-tracker.md` and in issue bodies (links of the form `acp-kernel/pull/<n>`); when an upstream PR is merged, the issue gets the `upstream-merged` label and an SOP comment. Requires `docs/upstream-tracker.md` to exist (skipped otherwise).
+
+Both jobs write to the project via a repository secret **GH_PROJECT_TOKEN** — a fine-grained PAT with the user-level **Projects → Read and write** permission (Project V2 GraphQL mutations need more than the default `GITHUB_TOKEN`). To activate the automation, add the secret under Settings → Secrets and variables → Actions. Without it, the workflow prints a notice and exits 0 (CI stays green; project fields are simply not updated).


### PR DESCRIPTION
## 问题

Issue 的优先级(upstream-pending / priority: P0-P2)目前靠手动同步到 GitHub Project「billion-context-dsh Roadmap」,打标签后容易忘记把 issue 加进项目或更新字段。

## 修复

新增 `.github/workflows/issue-triage.yml`,分两个 job:

**sync**(opened / labeled / unlabeled 触发)
1. 把 issue 加入 project #1(幂等,先查后加);
2. 按 `priority: P0/P1/P2/backlog` 标签设置 Priority 单选字段(Priority option id 运行时按 option name 查完整 `PVTSEO_` id,不硬编码);
3. 打 `upstream-pending` 时在 Upstream 字段写入提示(指向 docs/upstream-tracker.md);只响应当次事件的标签(`github.event.label.name`),不重算其他标签。

**watch-upstream**(每日 cron 3:23)
- 依据 docs/upstream-tracker.md 与 issue 正文中的 acp-kernel/pull 链接,上游 PR merged 时打 `upstream-merged` 标签并留言(幂等)。

Project V2 的 GraphQL 写操作需要比默认 GITHUB_TOKEN 更大的权限,因此走仓库 secret **GH_PROJECT_TOKEN**(fine-grained PAT,勾选 project 写权限)。secret 未配置时该步骤打印提示并跳过,不影响 CI 通过。

## 与前序 PR 的关系

- 本 PR 不含 release 版本号改动(曾误挂在 release/v0.2.15 head 上,已关闭原 #86 重建,#86 的 head 问题为 GitHub 同仓库 PR 不支持 API 切换 head 所致)。
- 依赖 #84(docs/upstream-tracker.md)先合并:watch-upstream job 对该文件有存在性保护,缺失时跳过。

## 审阅修复(9ef1f0c)

按审阅团队 findings 修复:Priority option id 运行时查询(F2)、item-add 先查后写不吞错(F3)、jq [0] 取代 head -1 避免 SIGPIPE(F4)、只同步本次事件标签+unlabeled 触发(F5)、cancel-in-progress: false(F1)、PROJECT_ID 一次查询复用(F6)、watch-upstream 独立 concurrency 组+tracker 文件保护(F7)。

## 验证

- YAML `safe_load` 通过;本地 awk 解析模拟通过(issue #46 → acp-kernel PR #123 配对成功)。
- 合并后可给任意 issue 打一个 priority 标签做冒烟验证,在 Project Board 上确认字段值变化。